### PR TITLE
Initial Commit - Foundation Converter Pipeline

### DIFF
--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/BatchConfiguration.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/BatchConfiguration.java
@@ -105,6 +105,7 @@ public class BatchConfiguration {
     }
 
     @Bean
+    @StepScope
     public CompositeItemWriter<CompositeResultBean> compositeWriter() {
         CompositeItemWriter writer = new CompositeItemWriter();
         List delegates = new ArrayList();

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/FoundationFileTasklet.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/FoundationFileTasklet.java
@@ -49,6 +49,9 @@ public class FoundationFileTasklet implements Tasklet {
             // since files are sorted by filename/date, cases in more than one file 
             // will automatically only have their most recent data converted
             for (CaseType ct : newCases) {
+                if (fmiCaseTypeMap.containsKey(ct.getCase())) {
+                    LOG.warn("Sample found in more than one file. Using current file to update data for sample: " + ct.getCase());
+                }
                 fmiCaseTypeMap.put(ct.getCase(), ct);
             }
         }


### PR DESCRIPTION
Converts Foundation XML data to staging file formats compatible with portal.
- Added support for full report version of Foundation XML data if not in expected format

Updates:
- Added step scope for composite item writer
- Added warning to let user know when a sample's data is being updated

Signed-off-by: Angelica Ochoa aochoa4230@gmail.com
