### PR TITLE
Changes to fusion event descriptions 

### DIFF
--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/FoundationReader.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/FoundationReader.java
@@ -59,8 +59,8 @@ public class FoundationReader implements ItemStreamReader<CaseType> {
         else {
             this.foundationCaseList = new ArrayList(foundationCaseListExecution);
         }
-        
     }
+        
     @Override
     public void update(ExecutionContext executionContext) throws ItemStreamException{}
     

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/FusionDataProcessor.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/FusionDataProcessor.java
@@ -53,10 +53,13 @@ public class FusionDataProcessor implements ItemProcessor<CaseType, String>{
             FusionData fd = new FusionData(caseType.getCase(), re);
             fusionRecords.add(transformRecord(fd));
             
-            // switch the targeted gene and other gene if other gene not empty
+            // switch the targeted gene and other gene if other gene not empty and if 
+            // other gene does not contain intergenic or '/'
             if (!FoundationUtils.NULL_EMPTY_VALUES.contains(re.getOtherGene()) 
-                    && !re.getOtherGene().equals(re.getTargetedGene())) {
+                    && !re.getOtherGene().equals(re.getTargetedGene()) && 
+                    !re.getOtherGene().contains("intergenic") && !re.getOtherGene().contains("/")) {
                 FusionData fdSwitched = FoundationUtils.getOtherGeneFusionEvent(caseType.getCase(), re);
+                fdSwitched.setFusion(fd.getFusion());
                 fusionRecords.add(transformRecord(fdSwitched));
             }
         }

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/RearrangementType.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/RearrangementType.java
@@ -56,7 +56,7 @@ import javax.xml.bind.annotation.*;
 public class RearrangementType {
      
     @XmlElement(name = "comment", required = false)
-     protected String comment;
+    private String comment;
      
     @XmlMixed
     protected List<Serializable> content;
@@ -213,6 +213,20 @@ public class RearrangementType {
      */
     public void setTargetedGene(String targetedGene) {
         this.targetedGene = targetedGene;
+    }
+
+    /**
+     * @return the comment
+     */
+    public String getComment() {
+        return comment;
+    }
+
+    /**
+     * @param comment the comment to set
+     */
+    public void setComment(String comment) {
+        this.comment = comment;
     }
     
  }

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/staging/FusionData.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/staging/FusionData.java
@@ -58,11 +58,12 @@ public class FusionData {
     
     public FusionData(String sampleId, RearrangementType rearrangement) {
         this.tumorSampleBarcode = sampleId;
-        this.gene = rearrangement.getTargetedGene();
+        this.gene = rearrangement.getTargetedGene().split("-")[0];
         this.entrezGeneId = "0"; 
         
         // resolve the fusion event
-        this.fusion = FoundationUtils.resolveFusionEvent(rearrangement.getTargetedGene(), rearrangement.getOtherGene());
+        this.fusion = FoundationUtils.resolveFusionEvent(this.gene, rearrangement.getOtherGene(), 
+                rearrangement.getDescription(), rearrangement.getComment());
 
         // resolve the rearrangement frame
         this.frame = FoundationUtils.resolveRearrangementFrame(rearrangement.getInFrame());

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/util/FoundationUtils.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/util/FoundationUtils.java
@@ -275,25 +275,30 @@ public class FoundationUtils {
      * Resolve the fusion event.
      * @param targetedGene
      * @param otherGene
+     * @param description
+     * @param comment
      * @return 
      */
-    public static String resolveFusionEvent(String targetedGene, String otherGene) {
+    public static String resolveFusionEvent(String targetedGene, String otherGene, String description, String comment) {
         String[] fusionEventParts = targetedGene.split("-");
         
         String fusionEvent = fusionEventParts[0];
         if (!Strings.isNullOrEmpty(otherGene) && !NULL_EMPTY_VALUES.contains(otherGene)
-                && !otherGene.equals(targetedGene)) {
-            fusionEvent += "-" + otherGene + " fusion";
+                && !otherGene.equals(targetedGene) && !otherGene.contains("intergenic")) {
+            fusionEvent += "-" + otherGene + " " +description;
         }
         else {
-            if (targetedGene.contains("intergenic") || otherGene.equals(targetedGene)) {
-                fusionEvent += "-" + "intragenic";
+            if (targetedGene.contains("intergenic") || otherGene.contains("intergenic")) {
+                fusionEvent += "-intragenic";
             }
             else {
-                fusionEvent += " fusion";
+                fusionEvent += " " + description;
             }
         }
-        
+
+        if (!Strings.isNullOrEmpty(comment)) {
+            fusionEvent += ": " + comment;
+        }
         return fusionEvent;
     }
     


### PR DESCRIPTION
- Fusion events are now described by what's provided in the Foundation xml
- Comments about fusion events from Foundation are appended to fusion events if not null or empty
- Fusions between two genes are now described by the same fusion event description instead of reversing the order of the targeted gene and other gene 

**Example**:
- **before fix:**

| Targeted Gene | Other Gene | Fusion |
| --- | --- | --- |
| Gene1 | Gene2 | Gene1-Gene2 fusion |
| Gene2 | Gene1 | _**Gene2-Gene1 fusion**_ |
- **after fix:**

| Targeted Gene | Other Gene | Fusion |
| --- | --- | --- |
| Gene1 | Gene2 | Gene1-Gene2 fusion |
| Gene2 | Gene1 | _**Gene1-Gene2 fusion**_ |
