### PR TITLE
Change default value for Tumor_Seq_Allele2

### DIFF
--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/staging/MutationData.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/staging/MutationData.java
@@ -142,7 +142,7 @@ public class MutationData {
          */
         this.center = FoundationUtils.FOUNDATION_CENTER;
         this.build = FoundationUtils.FOUNDATION_BUILD;
-        this.tumorAllele2 = FoundationUtils.FOUNDATION_NA;        
+        this.tumorAllele2 = FoundationUtils.FOUNDATION_EMPTY;        
         this.dbSNPRS = FoundationUtils.FOUNDATION_EMPTY;
         this.dbSNPValStatus = FoundationUtils.FOUNDATION_EMPTY;
         this.matchedNormSampleBarcode = FoundationUtils.FOUNDATION_EMPTY;


### PR DESCRIPTION
* sets default value to empty string instead of "NA"

Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>