### PR TITLE
Foundation XML Converter Updates

### DIFF
--- a/foundation/pom.xml
+++ b/foundation/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.cbio.portal.pipelines</groupId>
         <artifactId>master</artifactId>
-        <version>0.1.0</version>
+        <version>1.0.0</version>
     </parent>
     <artifactId>foundation</artifactId>
     <packaging>jar</packaging>

--- a/foundation/src/main/java/org/cbio/portal/pipelines/FoundationPipeline.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/FoundationPipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016-17 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -59,6 +59,7 @@ public class FoundationPipeline {
             .addOption("s", "source", true, "Foundation .XML source directory" )
             .addOption ("o", "output", true, "Output directory for writing staging files")
             .addOption ("c", "cancer_study_id", true, "Cancer study identifier for meta data")
+            .addOption("g", "gene_data_filename", true, "Path to gene symbol data file 'Homo_sapiens.gene_info'")
             .addOption("xml", "generate_xml", false, "Generate merged XML document ");
          
         return gnuOptions;
@@ -70,7 +71,7 @@ public class FoundationPipeline {
         System.exit(exitStatus);
     }  
             
-    private static void launchJob(String[] args, String sourceDirectory, String outputDirectory, String cancerStudyId, boolean generateXmlDocument) throws Exception {
+    private static void launchJob(String[] args, String sourceDirectory, String outputDirectory, String cancerStudyId, String geneDataFilename, boolean generateXmlDocument) throws Exception {
         // set up application context and job launcher
         SpringApplication app = new SpringApplication(FoundationPipeline.class);
         ConfigurableApplicationContext ctx= app.run(args);
@@ -86,6 +87,7 @@ public class FoundationPipeline {
                 .addString("sourceDirectory", sourceDirectory)
                 .addString("outputDirectory", outputDirectory)
                 .addString ("cancerStudyId", cancerStudyId)
+                .addString("geneDataFilename", geneDataFilename)
                 .toJobParameters();
         JobExecution jobExecution = jobLauncher.run(foundationJob, jobParameters);
         
@@ -104,9 +106,6 @@ public class FoundationPipeline {
             !commandLine.hasOption("cancer_study_id"))  {
             help(gnuOptions, 0);        
         }
-        for (String v : commandLine.getArgList()) {
-            System.out.println(v);
-        }
 
         // light pre-processing for source directory and output directory paths
         String sourceDirectory = commandLine.getOptionValue("source");
@@ -115,10 +114,12 @@ public class FoundationPipeline {
         if (!sourceDirectory.endsWith(File.separator)) sourceDirectory += File.separator;
         if (!outputDirectory.endsWith(File.separator)) outputDirectory += File.separator;
         
-        // determine whether to run xml document generator job or not
-        boolean generateXmlDocument = commandLine.hasOption("generate_xml");
-
-        launchJob(args, sourceDirectory, outputDirectory, cancerStudyId, generateXmlDocument);
+        String geneDataFilename = "";
+        if (commandLine.hasOption("g")) {
+            geneDataFilename = commandLine.getOptionValue("g");
+        }
+        
+        launchJob(args, sourceDirectory, outputDirectory, cancerStudyId, geneDataFilename, commandLine.hasOption("generate_xml"));
     }
     
 }

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/BatchConfiguration.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/BatchConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016-17 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -144,11 +144,11 @@ public class BatchConfiguration {
     @Bean
     public Step generalDataStep() {
         return stepBuilderFactory.get("generalDataStep")
+                .listener(foundationStepListener())
                 .<CaseType, CompositeResultBean> chunk(chunkInterval)
                 .reader(foundationReader())
                 .processor(foundationCompositeProcessor())
                 .writer(compositeWriter())
-                .listener(foundationStepListener())
                 .build();
     }    
     
@@ -171,6 +171,7 @@ public class BatchConfiguration {
     }
     
     @Bean 
+    @StepScope
     public FoundationCompositeProcessor foundationCompositeProcessor(){
         return new FoundationCompositeProcessor();
     }
@@ -212,10 +213,10 @@ public class BatchConfiguration {
     @Bean
     public Step cnaDataStep() {
         return stepBuilderFactory.get("cnaDataStep")
+            .listener(cnaStepListener())
             .<String, String> chunk(chunkInterval)
             .reader(cnaDataReader())
             .writer(cnaDataWriter())
-            .listener(cnaStepListener())
             .build();
     }        
     

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/ClinicalDataProcessor.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/ClinicalDataProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016-17 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -44,19 +44,38 @@ import org.springframework.batch.item.ItemProcessor;
  * @author Prithi Chakrapani, ochoaa
  */
 public class ClinicalDataProcessor implements ItemProcessor<CaseType, String> {
+    
+    private boolean addData;
+    private List<String> columns;
 
+    public void setProperties(boolean addData, List<String> columns) {
+        this.addData = addData;
+        this.columns = columns;
+    }
+    
     @Override
-    public String process(final CaseType caseType) throws Exception {
+    public String process(CaseType caseType) throws Exception {
         ClinicalData clinicalData = new ClinicalData(caseType);
         Map<String,String> map = clinicalData.getStagingMap();
         
+        // get standard clinical data values for record
         List<String> record = new ArrayList();
         for (String field : map.keySet()) {
             String value = clinicalData.getClass().getMethod(map.get(field)).invoke(clinicalData).toString();
             record.add(value);
         }
         
-        return StringUtils.join(record, "\t");        
+        // add non-human content data to record for if applicable
+        if (addData) {
+            for (String organism : columns) {
+                String value = "";
+                if (clinicalData.getAdditionalProperties().containsKey(organism)) {
+                    value = clinicalData.getAdditionalProperties().get(organism);
+                }
+                record.add(value);
+            }
+        }
+        return StringUtils.join(record, "\t");
     }
-    
+
 }

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/CnaDataReader.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/CnaDataReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016-17 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -33,19 +33,23 @@
 package org.cbio.portal.pipelines.foundation;
 
 import org.cbio.portal.pipelines.foundation.model.*;
-import org.cbio.portal.pipelines.foundation.util.FoundationUtils;
+import org.cbio.portal.pipelines.foundation.util.*;
 
 import java.util.*;
 import org.apache.commons.collections.map.MultiKeyMap;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.*;
 import org.springframework.batch.item.*;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  *
  * @author ochoaa
  */
 public class CnaDataReader implements ItemStreamReader<String> {
+    
+    @Autowired
+    GeneDataUtils geneDataUtils;
     
     private List<String> foundationCnaRowData;
     private static final Log LOG = LogFactory.getLog(CnaDataReader.class);
@@ -70,8 +74,16 @@ public class CnaDataReader implements ItemStreamReader<String> {
             List<CopyNumberAlterationType> cnaTypeList = ct.getVariantReport().getCopyNumberAlterations().getCopyNumberAlteration();
             if (cnaTypeList != null) {
                 for (CopyNumberAlterationType cnaType : cnaTypeList) {
-                    cnaMap.put(cnaType.getGene(), ct.getCase(), FoundationUtils.resolveCnaType(cnaType));
-                    geneList.add(cnaType.getGene());
+                    // create cna record for each gene in cna event
+                    List<String> cnaGenes = geneDataUtils.resolveGeneSymbolList(cnaType.getGene().split("/"));
+                    for (String gene : cnaGenes) {
+                        if (geneDataUtils.isNcRNA(gene)) {
+                            LOG.info("Skipping CNA record with ncRNA: " + gene);
+                            continue;
+                        }                        
+                        cnaMap.put(gene, ct.getCase(), FoundationUtils.resolveCnaType(cnaType));
+                        geneList.add(gene);
+                    }
                 }
             }
             else {
@@ -85,8 +97,9 @@ public class CnaDataReader implements ItemStreamReader<String> {
         // format row data for CNA file                
         List<String> cnaRowData = new ArrayList();
         for (String gene : geneList) {            
-            List<String> geneCnaData = new ArrayList();
+            List<String> geneCnaData = new ArrayList();            
             geneCnaData.add(gene);
+            geneCnaData.add(geneDataUtils.resolveEntrezId(gene));
             for (String caseId : fmiCaseTypeMap.keySet()) {
                 if (cnaMap.containsKey(gene, caseId)) {
                     geneCnaData.add((String) cnaMap.get(gene, caseId));

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/CnaStepListener.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/CnaStepListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/CompositeResultBean.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/CompositeResultBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/FoundationCompositeProcessor.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/FoundationCompositeProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016-17 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -33,23 +33,41 @@
 package org.cbio.portal.pipelines.foundation;
 
 import org.cbio.portal.pipelines.foundation.model.CaseType;
+import org.cbio.portal.pipelines.foundation.util.GeneDataUtils;
 
+import java.util.List;
 import org.apache.commons.logging.*;
 import org.springframework.batch.item.ItemProcessor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 
 /**
  *
  * @author ochoaa
  */
 public class FoundationCompositeProcessor implements ItemProcessor<CaseType, CompositeResultBean>{
-     private static final Log LOG = LogFactory.getLog(FoundationCompositeProcessor.class);
+
+    @Value("#{stepExecutionContext['addNonHumanContentData']}")
+    private boolean addData;
     
-    private final ClinicalDataProcessor clinicalDataProcessor= new ClinicalDataProcessor();
+    @Value("#{stepExecutionContext['nonHumanContentColumns']}")
+    private List<String> columns;
+    
+    @Autowired
+    private GeneDataUtils geneDataUtils;
+    
+    private final ClinicalDataProcessor clinicalDataProcessor = new ClinicalDataProcessor();
     private final MutationDataProcessor mutationDataProcessor = new MutationDataProcessor();
     private final FusionDataProcessor fusionDataProcessor = new FusionDataProcessor();
-        
+    
+    private static final Log LOG = LogFactory.getLog(FoundationCompositeProcessor.class);
+    
     @Override
     public CompositeResultBean process(CaseType ct) throws Exception {
+        // set properties for clinical, mutation, and fusion data processors
+        clinicalDataProcessor.setProperties(addData, columns);
+        mutationDataProcessor.setProperties(geneDataUtils);
+        fusionDataProcessor.setProperties(geneDataUtils);
         
         final CompositeResultBean compositeResultBean = new CompositeResultBean();
         try {

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/FoundationReader.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/FoundationReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016-17 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -37,12 +37,16 @@ import org.cbio.portal.pipelines.foundation.model.CaseType;
 import java.util.*;
 import org.apache.commons.logging.*;
 import org.springframework.batch.item.*;
+import org.springframework.beans.factory.annotation.Value;
 
 /**
  *
  * @author ochoaa
  */
 public class FoundationReader implements ItemStreamReader<CaseType> {
+    
+    @Value("#{stepExecutionContext['fmiCaseList']}")
+    private List<CaseType> fmiCaseList;
     
     private List<CaseType> foundationCaseList = new ArrayList();
     
@@ -51,13 +55,12 @@ public class FoundationReader implements ItemStreamReader<CaseType> {
     @Override
     public void open(ExecutionContext executionContext) throws ItemStreamException {           
        
-        // retrieve list of foundation cases from execution context
-        List<CaseType> foundationCaseListExecution = (List<CaseType>) executionContext.get("fmiCaseList");
-        if (foundationCaseListExecution.isEmpty() || foundationCaseListExecution == null) {
+        // check list of foundation cases from execution context
+        if (fmiCaseList.isEmpty() || fmiCaseList == null) {
             LOG.error("Error retrieving Foundation case list from execution context.");
         }
         else {
-            this.foundationCaseList = new ArrayList(foundationCaseListExecution);
+            this.foundationCaseList = new ArrayList(fmiCaseList);
         }
     }
         

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/FoundationStepListener.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/FoundationStepListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -50,6 +50,8 @@ public class FoundationStepListener implements StepExecutionListener {
         ExecutionContext executionContext = stepExecution.getJobExecution().getExecutionContext();
         Map<String, CaseType> fmiCaseTypeMap = (Map<String, CaseType>) executionContext.get("fmiCaseTypeMap");
         stepExecution.getExecutionContext().put("fmiCaseList", new ArrayList(fmiCaseTypeMap.values()));
+        stepExecution.getExecutionContext().put("addNonHumanContentData", executionContext.get("addNonHumanContentData"));
+        stepExecution.getExecutionContext().put("nonHumanContentColumns", executionContext.get("nonHumanContentColumns"));
     }     
 
     @Override

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/FoundationXmlGeneratorListener.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/FoundationXmlGeneratorListener.java
@@ -1,8 +1,35 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Copyright (c) 2017 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
  */
+
+/*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 package org.cbio.portal.pipelines.foundation;
 
 import org.cbio.portal.pipelines.foundation.model.CaseType;

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/FoundationXmlGeneratorTasklet.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/FoundationXmlGeneratorTasklet.java
@@ -1,8 +1,35 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Copyright (c) 2017 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
  */
+
+/*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 package org.cbio.portal.pipelines.foundation;
 
 import org.cbio.portal.pipelines.foundation.model.*;
@@ -24,19 +51,19 @@ import org.springframework.beans.factory.annotation.Value;
  */
 public class FoundationXmlGeneratorTasklet implements Tasklet {
     
-   @Value("#{jobParameters[outputDirectory]}")
+    @Value("#{jobParameters[outputDirectory]}")
     private String outputDirectory;
-   
+
     @Value("#{jobParameters[cancerStudyId]}")
     private String cancerStudyIdentifier;
     
+    @Value("#{stepExecutionContext['fmiCaseTypeMap']}")
+    private Map<String, CaseType> fmiCaseTypeMap;
+
     private static final Log LOG = LogFactory.getLog(FoundationXmlGeneratorTasklet.class);
     
     @Override
-    public RepeatStatus execute(StepContribution stepContext, ChunkContext chunkContext) throws Exception {
-        // get fmi case type map from execution context
-        Map<String, CaseType>  fmiCaseTypeMap = (Map<String, CaseType> ) chunkContext.getStepContext().getJobExecutionContext().get("fmiCaseTypeMap");
-        
+    public RepeatStatus execute(StepContribution stepContext, ChunkContext chunkContext) throws Exception {        
         // create new client case info type object to generate merged xml document
         ClientCaseInfoType clientCaseInfo = new ClientCaseInfoType();
         CasesType cases = new CasesType();
@@ -53,17 +80,17 @@ public class FoundationXmlGeneratorTasklet implements Tasklet {
      * 
      * @param clientCaseInfo
      */
-    private void writeFoundationXmlDocument(ClientCaseInfoType clientCaseInfo) {
+    private void writeFoundationXmlDocument(ClientCaseInfoType clientCaseInfo) throws IOException {
         String xmlData = null;
         StringWriter sw = new StringWriter();
-        String outputFilename = outputDirectory + File.separator + cancerStudyIdentifier + "_merged.xml";
+        File outputFile = new File(outputDirectory,cancerStudyIdentifier + "_merged.xml");
         try {
             JAXBContext context = JAXBContext.newInstance(clientCaseInfo.getClass());
             Marshaller jaxbMarshaller = context.createMarshaller();
             jaxbMarshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
-            jaxbMarshaller.marshal(clientCaseInfo, new File(outputFilename));
+            jaxbMarshaller.marshal(clientCaseInfo, outputFile);
             xmlData = sw.toString();
-            LOG.info("Merged Foundation XML document written to: " + outputFilename);
+            LOG.info("Merged Foundation XML document written to: " + outputFile.getCanonicalPath());
         }
         catch (JAXBException ex) {
             LOG.error("Error marshalling XML document from client case info object");

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/FusionDataWriter.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/FusionDataWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -38,7 +38,6 @@ import java.io.*;
 import java.util.*;
 import com.google.common.base.Strings;
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.*;
 
 import org.springframework.batch.item.*;
 import org.springframework.batch.item.file.*;
@@ -55,15 +54,12 @@ public class FusionDataWriter implements ItemStreamWriter <CompositeResultBean> 
    @Value("#{jobParameters[outputDirectory]}")
     private String outputDirectory; 
 
-    private static final Log LOG = LogFactory.getLog(FusionDataWriter.class);   
-
-    private final List<String> writeList = new ArrayList<>();
+    private final List<String> writeList = new ArrayList();
     private final FlatFileItemWriter<String> flatFileItemWriter = new FlatFileItemWriter<>();
         
     @Override
     public void open(ExecutionContext executionContext) throws ItemStreamException {
-        String stagingFile = outputDirectory +  "data_fusions.txt" ;
-                
+        File stagingFile = new File(outputDirectory, "data_fusions.txt");
         PassThroughLineAggregator aggr = new PassThroughLineAggregator();
         flatFileItemWriter.setLineAggregator(aggr);
         flatFileItemWriter.setHeaderCallback(new FlatFileHeaderCallback() {
@@ -89,23 +85,20 @@ public class FusionDataWriter implements ItemStreamWriter <CompositeResultBean> 
     public void update(ExecutionContext executionContext) throws ItemStreamException {}
 
     @Override
-    public void close() throws ItemStreamException
-    {
+    public void close() throws ItemStreamException {
         flatFileItemWriter.close();
     }
 
     @Override
-    public void write(List<? extends CompositeResultBean> items) throws Exception
-    {
+    public void write(List<? extends CompositeResultBean> items) throws Exception {
         writeList.clear();
-        List<String> writeList = new ArrayList<String>();
+        List<String> writeList = new ArrayList();
         for (CompositeResultBean resultList : items) {
             for (String result : resultList.getFusionDataResult().split("\n")) {
                 if (!Strings.isNullOrEmpty(result)) {
                     writeList.add(result);
                 }
             }
-            
         }
         flatFileItemWriter.write(writeList);
     }

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/MetaDataConfiguration.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/MetaDataConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/MetaDataTasklet.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/MetaDataTasklet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/BiomarkersType.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/BiomarkersType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-17 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2017 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -32,55 +32,74 @@
 
 package org.cbio.portal.pipelines.foundation.model;
 
+import java.io.Serializable;
+import java.util.*;
 import javax.xml.bind.annotation.*;
 
 /**
  *
  * @author ochoaa
  */
-@XmlRootElement(name="ResultsReport")
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlType(name = "ResultsReportType", propOrder = {
-    "variantReport",
-    "resultsPayload"
+@XmlType(name = "BiomarkersType", propOrder = {
+    "content",
+    "microsatelliteInstability", 
+    "tumorMutationBurden"
 })
-public class ResultsReportType {
+public class BiomarkersType {
     
-    @XmlElement(name = "variant-report", required = false)
-    protected VariantReportType variantReport;
-    
-    @XmlElement(name = "ResultsPayload", required = false)
-    protected ResultsPayloadType resultsPayload;
+    @XmlMixed
+    protected List<Serializable> content;
+
+    @XmlElement(name = "microsatellite-instability", required = false)
+    protected MicrosatelliteInstabilityType microsatelliteInstability;
+
+    @XmlElement(name = "tumor-mutation-burden", required = false)
+    protected TumorMutationBurdenType tumorMutationBurden;
 
     /**
-     * @return the variantReport
+     * @return the content
      */
-    public VariantReportType getVariantReport() {
-        if (variantReport == null) {
-            return resultsPayload.getVariantReport();
+    public List<Serializable> getContent() {
+        if (content == null) {
+            content = new ArrayList<>();
         }
-        return variantReport;
+        return this.content;
+    }    
+    
+    /**
+     * @param content the content to set
+     */
+    public void setContent(List<Serializable> content) {
+        this.content = content;
+    }
+    
+    /**
+     * @return the microsatelliteInstability
+     */
+    public MicrosatelliteInstabilityType getMicrosatelliteInstability() {
+        return microsatelliteInstability;
     }
 
     /**
-     * @param variantReport the variantReport to set
+     * @param microsatelliteInstability the microsatelliteInstability to set
      */
-    public void setVariantReport(VariantReportType variantReport) {
-        this.variantReport = variantReport;
+    public void setMicrosatelliteInstability(MicrosatelliteInstabilityType microsatelliteInstability) {
+        this.microsatelliteInstability = microsatelliteInstability;
     }
 
     /**
-     * @return the resultsPayload
+     * @return the tumorMutationBurden
      */
-    public ResultsPayloadType getResultsPayload() {
-        return resultsPayload;
+    public TumorMutationBurdenType getTumorMutationBurden() {
+        return tumorMutationBurden;
     }
 
     /**
-     * @param resultsPayload the resultsPayload to set
+     * @param tumorMutationBurden the tumorMutationBurden to set
      */
-    public void setResultsPayloadType(ResultsPayloadType resultsPayload) {
-        this.resultsPayload = resultsPayload;
+    public void setTumorMutationBurden(TumorMutationBurdenType tumorMutationBurden) {
+        this.tumorMutationBurden = tumorMutationBurden;
     }
     
 }

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/CaseType.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/CaseType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/CasesType.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/CasesType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/ClientCaseInfoType.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/ClientCaseInfoType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/CopyNumberAlterationType.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/CopyNumberAlterationType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016-17 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -40,15 +40,23 @@ import javax.xml.bind.annotation.*;
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "CopyNumberAlterationType", propOrder = {
-    "value"
+    "dnaEvidence",
+    "rnaEvidence"
 })
 public class CopyNumberAlterationType {
-    @XmlValue
-    protected String value;
+    
+    @XmlElement(name = "dna-evidence", required = false)
+    protected DnaEvidenceType dnaEvidence;
+
+    @XmlElement(name = "rna-evidence", required = false)
+    protected RnaEvidenceType rnaEvidence;
    
     @XmlAttribute(name = "copy-number")
     protected Byte copyNumber;
    
+    @XmlAttribute(name = "equivocal")
+    protected boolean equivocal;
+    
     @XmlAttribute(name = "gene")
     protected String gene;
    
@@ -68,19 +76,33 @@ public class CopyNumberAlterationType {
     protected String type;
 
     /**
-     * @return the value
+     * @return the dnaEvidence
      */
-    public String getValue() {
-        return value;
+    public DnaEvidenceType getDnaEvidence() {
+        return dnaEvidence;
     }
 
     /**
-     * @param value the value to set
+     * @param dnaEvidence the dnaEvidence to set
      */
-    public void setValue(String value) {
-        this.value = value;
+    public void setDnaEvidence(DnaEvidenceType dnaEvidence) {
+        this.dnaEvidence = dnaEvidence;
     }
 
+    /**
+     * @return the rnaEvidence
+     */
+    public RnaEvidenceType getRnaEvidence() {
+        return rnaEvidence;
+    }
+
+    /**
+     * @param rnaEvidence the rnaEvidence to set
+     */
+    public void setRnaEvidence(RnaEvidenceType rnaEvidence) {
+        this.rnaEvidence = rnaEvidence;
+    }
+    
     /**
      * @return the copyNumber
      */
@@ -95,6 +117,20 @@ public class CopyNumberAlterationType {
         this.copyNumber = copyNumber;
     }
 
+    /**
+     * @return the equivocal
+     */
+    public boolean isEquivocal() {
+        return equivocal;
+    }
+
+    /**
+     * @param equivocal the equivocal to set
+     */
+    public void setEquivocal(boolean equivocal) {
+        this.equivocal = equivocal;
+    }
+    
     /**
      * @return the gene
      */

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/CopyNumberAlterationsType.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/CopyNumberAlterationsType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016-17 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -46,7 +46,7 @@ import javax.xml.bind.annotation.*;
 public class CopyNumberAlterationsType {
 
     @XmlElement(name = "copy-number-alteration", required = false)
-    private List<CopyNumberAlterationType> copyNumberAlteration;
+    protected List<CopyNumberAlterationType> copyNumberAlteration;
 
     /**
      * @return the copyNumberAlteration

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/DnaEvidenceType.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/DnaEvidenceType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2017 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -36,46 +36,29 @@ import javax.xml.bind.annotation.*;
 
 /**
  *
- * @author Prithi Chakrapani, ochoaa
+ * @author ochoaa
  */
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlType(name = "QualityControlType", propOrder = { 
-    "metrics" 
+@XmlType(name = "DnaEvidenceType", propOrder = {
+    "sampleEvidence"
 })
-public class QualityControlType {
+public class DnaEvidenceType {
     
-    @XmlElement(required = true)
-    protected MetricsType metrics;
-    
-    @XmlAttribute(name = "status")
-    protected String status;
+    @XmlAttribute(name = "sample")
+    protected String sampleEvidence;
 
     /**
-     * @return the metrics
+     * @return the sampleEvidence
      */
-    public MetricsType getMetrics() {
-        return metrics;
+    public String getSampleEvidence() {
+        return sampleEvidence;
     }
 
     /**
-     * @param metrics the metrics to set
+     * @param sampleEvidence the sampleEvidence to set
      */
-    public void setMetrics(MetricsType metrics) {
-        this.metrics = metrics;
+    public void setSampleEvidence(String sampleEvidence) {
+        this.sampleEvidence = sampleEvidence;
     }
-
-    /**
-     * @return the status
-     */
-    public String getStatus() {
-        return status;
-    }
-
-    /**
-     * @param status the status to set
-     */
-    public void setStatus(String status) {
-        this.status = status;
-    }
-    
+        
 }

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/MetricType.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/MetricType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/MetricsType.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/MetricsType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016-17 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -39,12 +39,13 @@ import javax.xml.bind.annotation.*;
  *
  * @author Prithi Chakrapani, ochoaa
  */
- @XmlAccessorType(XmlAccessType.FIELD)
+@XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "MetricsType", propOrder = {
     "metric"
 })
 public class MetricsType {
    
+    @XmlElement(required = false)
     protected List<MetricType> metric;
 
     /**

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/MicrosatelliteInstabilityType.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/MicrosatelliteInstabilityType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2017 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -36,33 +36,16 @@ import javax.xml.bind.annotation.*;
 
 /**
  *
- * @author Prithi Chakrapani, ochoaa
+ * @author ochoaa
  */
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlType(name = "QualityControlType", propOrder = { 
-    "metrics" 
+@XmlType(name = "MicrosatelliteInstabilityType", propOrder = {
+    "status"
 })
-public class QualityControlType {
+public class MicrosatelliteInstabilityType {
     
     @XmlElement(required = true)
-    protected MetricsType metrics;
-    
-    @XmlAttribute(name = "status")
-    protected String status;
-
-    /**
-     * @return the metrics
-     */
-    public MetricsType getMetrics() {
-        return metrics;
-    }
-
-    /**
-     * @param metrics the metrics to set
-     */
-    public void setMetrics(MetricsType metrics) {
-        this.metrics = metrics;
-    }
+    protected String status; 
 
     /**
      * @return the status

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/NonHumanContentType.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/NonHumanContentType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2017 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -32,50 +32,50 @@
 
 package org.cbio.portal.pipelines.foundation.model;
 
+import java.util.*;
 import javax.xml.bind.annotation.*;
 
 /**
  *
- * @author Prithi Chakrapani, ochoaa
+ * @author ochoaa
  */
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlType(name = "QualityControlType", propOrder = { 
-    "metrics" 
+@XmlType(name = "NonHumanContentType", propOrder = {
+    "nonHuman"
 })
-public class QualityControlType {
+public class NonHumanContentType {
     
-    @XmlElement(required = true)
-    protected MetricsType metrics;
-    
-    @XmlAttribute(name = "status")
-    protected String status;
+    @XmlElement(name = "non-human", required = false)
+    protected List<NonHumanType> nonHuman;
 
     /**
-     * @return the metrics
+     * @return the nonHuman
      */
-    public MetricsType getMetrics() {
-        return metrics;
+    public List<NonHumanType> getNonHuman() {
+        if (nonHuman == null) {
+            nonHuman = new ArrayList();
+        }
+        return nonHuman;
     }
 
     /**
-     * @param metrics the metrics to set
+     * @param nonHuman the nonHuman to set
      */
-    public void setMetrics(MetricsType metrics) {
-        this.metrics = metrics;
-    }
-
-    /**
-     * @return the status
-     */
-    public String getStatus() {
-        return status;
-    }
-
-    /**
-     * @param status the status to set
-     */
-    public void setStatus(String status) {
-        this.status = status;
+    public void setNonHuman(List<NonHumanType> nonHuman) {
+        this.nonHuman = nonHuman;
     }
     
+    /**
+     * Returns HashMap of non-human content data.
+     * @return 
+     */
+    public Map<String, String> getNonHumanContentData() {
+        Map<String, String> nonHumanContentData = new HashMap<>();
+        for (NonHumanType nht : nonHuman) {
+            nonHumanContentData.put(nht.getOrganism(), nht.getStatus());            
+        }
+        
+        return nonHumanContentData;
+    }
+
 }

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/NonHumanType.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/NonHumanType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2017 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -36,32 +36,70 @@ import javax.xml.bind.annotation.*;
 
 /**
  *
- * @author Prithi Chakrapani, ochoaa
+ * @author ochoaa
  */
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlType(name = "QualityControlType", propOrder = { 
-    "metrics" 
+@XmlType(name = "NonHumanType", propOrder = {
+    "dnaEvidence",
+    "rnaEvidence"
 })
-public class QualityControlType {
+public class NonHumanType {
+
+    @XmlElement(name = "dna-evidence", required = false)
+    protected DnaEvidenceType dnaEvidence;
+
+    @XmlElement(name = "rna-evidence", required = false)
+    protected RnaEvidenceType rnaEvidence;
     
-    @XmlElement(required = true)
-    protected MetricsType metrics;
+    @XmlAttribute(name = "organism")
+    protected String organism;
     
     @XmlAttribute(name = "status")
     protected String status;
-
+    
+    @XmlAttribute(name = "reads-per-million")
+    protected Integer readsPerMillion;
+    
     /**
-     * @return the metrics
+     * @return the dnaEvidence
      */
-    public MetricsType getMetrics() {
-        return metrics;
+    public DnaEvidenceType getDnaEvidence() {
+        return dnaEvidence;
     }
 
     /**
-     * @param metrics the metrics to set
+     * @param dnaEvidence the dnaEvidence to set
      */
-    public void setMetrics(MetricsType metrics) {
-        this.metrics = metrics;
+    public void setDnaEvidence(DnaEvidenceType dnaEvidence) {
+        this.dnaEvidence = dnaEvidence;
+    }
+
+    /**
+     * @return the rnaEvidence
+     */
+    public RnaEvidenceType getRnaEvidence() {
+        return rnaEvidence;
+    }
+
+    /**
+     * @param rnaEvidence the rnaEvidence to set
+     */
+    public void setRnaEvidence(RnaEvidenceType rnaEvidence) {
+        this.rnaEvidence = rnaEvidence;
+    }
+
+    /**
+     * @return the organism
+     */
+    public String getOrganism() {
+        return organism;
+    }
+
+    /**
+     * @param organism the organism to set
+     */
+    public void setOrganism(String organism) {
+        this.organism = organism;
     }
 
     /**
@@ -77,5 +115,19 @@ public class QualityControlType {
     public void setStatus(String status) {
         this.status = status;
     }
-    
+
+    /**
+     * @return the readsPerMillion
+     */
+    public Integer getReadsPerMillion() {
+        return readsPerMillion;
+    }
+
+    /**
+     * @param readsPerMillion the readsPerMillion to set
+     */
+    public void setReadsPerMillion(Integer readsPerMillion) {
+        this.readsPerMillion = readsPerMillion;
+    }
+        
 }

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/RearrangementType.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/RearrangementType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016-17 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -43,20 +43,20 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "RearrangementType", propOrder = {
     "comment",
-    "content",
-    "description",
-    "inFrame",
-    "otherGene",
-    "pos1",
-    "pos2",
-    "status",
-    "supportingReadPairs",
-    "targetedGene"
+    "dnaEvidence",
+    "rnaEvidence",
+    "content"
 })
 public class RearrangementType {
      
     @XmlElement(name = "comment", required = false)
-    private String comment;
+    protected String comment;
+    
+    @XmlElement(name = "dna-evidence", required = false)
+    protected DnaEvidenceType dnaEvidence;
+
+    @XmlElement(name = "rna-evidence", required = false)
+    protected RnaEvidenceType rnaEvidence;
      
     @XmlMixed
     protected List<Serializable> content;
@@ -64,6 +64,9 @@ public class RearrangementType {
     @XmlAttribute(name = "description")
     protected String description;
 
+    @XmlAttribute(name = "equivocal")
+    protected boolean equivocal;
+    
     @XmlAttribute(name = "in-frame")
     protected String inFrame;
 
@@ -85,13 +88,57 @@ public class RearrangementType {
     @XmlAttribute(name = "targeted-gene")
     protected String targetedGene;
 
+    @XmlAttribute(name = "type")
+    protected String type;
+    
+    /**
+     * @return the comment
+     */
+    public String getComment() {
+        return comment;
+    }
 
+    /**
+     * @param comment the comment to set
+     */
+    public void setComment(String comment) {
+        this.comment = comment;
+    }
+    
+    /**
+     * @return the dnaEvidence
+     */
+    public DnaEvidenceType getDnaEvidence() {
+        return dnaEvidence;
+    }
+
+    /**
+     * @param dnaEvidence the dnaEvidence to set
+     */
+    public void setDnaEvidence(DnaEvidenceType dnaEvidence) {
+        this.dnaEvidence = dnaEvidence;
+    }
+
+    /**
+     * @return the rnaEvidence
+     */
+    public RnaEvidenceType getRnaEvidence() {
+        return rnaEvidence;
+    }
+
+    /**
+     * @param rnaEvidence the rnaEvidence to set
+     */
+    public void setRnaEvidence(RnaEvidenceType rnaEvidence) {
+        this.rnaEvidence = rnaEvidence;
+    }
+    
     /**
      * @return the content
      */
     public List<Serializable> getContent() {
         if (content == null) {
-            content = new ArrayList<Serializable>();
+            content = new ArrayList<>();
         }
         return this.content;
     }    
@@ -117,6 +164,20 @@ public class RearrangementType {
         this.description = description;
     }
 
+    /**
+     * @return the equivocal
+     */
+    public boolean isEquivocal() {
+        return equivocal;
+    }
+
+    /**
+     * @param equivocal the equivocal to set
+     */
+    public void setEquivocal(boolean equivocal) {
+        this.equivocal = equivocal;
+    }
+    
     /**
      * @return the inFrame
      */
@@ -214,19 +275,19 @@ public class RearrangementType {
     public void setTargetedGene(String targetedGene) {
         this.targetedGene = targetedGene;
     }
-
+    
     /**
-     * @return the comment
+     * @return the type
      */
-    public String getComment() {
-        return comment;
+    public String getType() {
+        return type;
     }
 
     /**
-     * @param comment the comment to set
+     * @param type the type to set
      */
-    public void setComment(String comment) {
-        this.comment = comment;
+    public void setType(String type) {
+        this.type = type;
     }
     
  }

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/RearrangementsType.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/RearrangementsType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/ResultsPayloadType.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/ResultsPayloadType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2017 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -36,46 +36,29 @@ import javax.xml.bind.annotation.*;
 
 /**
  *
- * @author Prithi Chakrapani, ochoaa
+ * @author ochoaa
  */
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlType(name = "QualityControlType", propOrder = { 
-    "metrics" 
+@XmlType(name = "ResultsPayloadType", propOrder = {
+    "variantReport",
 })
-public class QualityControlType {
+public class ResultsPayloadType {        
     
-    @XmlElement(required = true)
-    protected MetricsType metrics;
-    
-    @XmlAttribute(name = "status")
-    protected String status;
+    @XmlElement(name = "variant-report", required = true)
+    protected VariantReportType variantReport;
 
     /**
-     * @return the metrics
+     * @return the variantReport
      */
-    public MetricsType getMetrics() {
-        return metrics;
+    public VariantReportType getVariantReport() {
+        return variantReport;
     }
 
     /**
-     * @param metrics the metrics to set
+     * @param variantReport the variantReport to set
      */
-    public void setMetrics(MetricsType metrics) {
-        this.metrics = metrics;
-    }
-
-    /**
-     * @return the status
-     */
-    public String getStatus() {
-        return status;
-    }
-
-    /**
-     * @param status the status to set
-     */
-    public void setStatus(String status) {
-        this.status = status;
+    public void setVariantReport(VariantReportType variantReport) {
+        this.variantReport = variantReport;
     }
     
 }

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/RnaEvidenceType.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/RnaEvidenceType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2017 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -36,46 +36,29 @@ import javax.xml.bind.annotation.*;
 
 /**
  *
- * @author Prithi Chakrapani, ochoaa
+ * @author ochoaa
  */
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlType(name = "QualityControlType", propOrder = { 
-    "metrics" 
+@XmlType(name = "RnaEvidenceType", propOrder = {
+    "sampleEvidence"
 })
-public class QualityControlType {
+public class RnaEvidenceType {
     
-    @XmlElement(required = true)
-    protected MetricsType metrics;
-    
-    @XmlAttribute(name = "status")
-    protected String status;
+    @XmlAttribute(name = "sample")
+    protected String sampleEvidence;
 
     /**
-     * @return the metrics
+     * @return the sampleEvidence
      */
-    public MetricsType getMetrics() {
-        return metrics;
+    public String getSampleEvidence() {
+        return sampleEvidence;
     }
 
     /**
-     * @param metrics the metrics to set
+     * @param sampleEvidence the sampleEvidence to set
      */
-    public void setMetrics(MetricsType metrics) {
-        this.metrics = metrics;
+    public void setSampleEvidence(String sampleEvidence) {
+        this.sampleEvidence = sampleEvidence;
     }
-
-    /**
-     * @return the status
-     */
-    public String getStatus() {
-        return status;
-    }
-
-    /**
-     * @param status the status to set
-     */
-    public void setStatus(String status) {
-        this.status = status;
-    }
-    
+        
 }

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/SampleType.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/SampleType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016-17 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -40,43 +40,55 @@ import javax.xml.bind.annotation.*;
  *
  * @author Prithi Chakrapani, ochoaa
  */
- @XmlAccessorType(XmlAccessType.FIELD)
+@XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "SampleType", propOrder = {
     "comment", 
     "content",
     "baitSet",
     "meanExonDepth",
+    "nucleicAcid",
     "percentTumorNuclei"        
 })
 public class SampleType {
     
-   @XmlElement(name = "comment", required = false)
-   protected String comment;
-   
-   @XmlMixed
-   protected List<Serializable> content;
-   
-   @XmlAttribute(name = "bait-set")
-   protected String baitSet;
-   
-   @XmlAttribute(name = "mean-exon-depth")
-   protected Float meanExonDepth;
-   
-   @XmlAttribute(name = "name" )
-   protected String name;
-   
-   @XmlAttribute(name = "percent-tumor-nuclei")
-   protected Integer percentTumorNuclei;
+    @XmlElement(name = "comment", required = false)
+    protected String comment;
+
+    @XmlMixed
+    protected List<Serializable> content;
+
+    @XmlAttribute(name = "bait-set")
+    protected String baitSet;
+
+    @XmlAttribute(name = "mean-exon-depth")
+    protected Float meanExonDepth;
+
+    @XmlAttribute(name = "name" )
+    protected String name;
+    
+    @XmlAttribute(name = "nucleic-acid-type")
+    protected String nucleicAcid;
+    
+    // this field will be kept to allow processing of data in older schema format
+    @XmlAttribute(name = "percent-tumor-nuclei")
+    protected Integer percentTumorNuclei;
    
     /**
      * @return the content
      */
     public List<Serializable> getContent() {
         if (content == null) {
-            content = new ArrayList<Serializable>();
+            content = new ArrayList<>();
         }
         return this.content;
-    }   
+    }    
+    
+    /**
+     * @param content the content to set
+     */
+    public void setContent(List<Serializable> content) {
+        this.content = content;
+    }
 
     /**
      * @return the baitSet
@@ -120,6 +132,20 @@ public class SampleType {
         this.name = name;
     }
 
+    /**
+     * @return the nucleicAcid
+     */
+    public String getNucleicAcid() {
+        return nucleicAcid;
+    }
+
+    /**
+     * @param nucleicAcid the nucleicAcid to set
+     */
+    public void setNucleicAcid(String nucleicAcid) {
+        this.nucleicAcid = nucleicAcid;
+    }
+    
     /**
      * @return the percentTumorNuclei
      */

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/SamplesType.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/SamplesType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/ShortVariantType.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/ShortVariantType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016-17 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -39,18 +39,28 @@ import javax.xml.bind.annotation.*;
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "ShortVariantType", propOrder = { 
-    "value"
+    "dnaEvidence",
+    "rnaEvidence"
 })
 public class ShortVariantType {
+    
+    @XmlElement(name = "dna-evidence", required = false)
+    protected DnaEvidenceType dnaEvidence;
 
-    @XmlValue
-    protected String value;
+    @XmlElement(name = "rna-evidence", required = false)
+    protected RnaEvidenceType rnaEvidence;
+    
+    @XmlAttribute(name = "allele-fraction")
+    protected Float alleleFraction;
     
     @XmlAttribute(name = "cds-effect")
     protected String cdsEffect;
     
     @XmlAttribute(name = "depth")
-    protected Short depth; 
+    protected Short depth;
+    
+    @XmlAttribute(name = "equivocal")
+    protected boolean equivocal;
     
     @XmlAttribute(name = "functional-effect")
     protected String functionalEffect;
@@ -77,19 +87,47 @@ public class ShortVariantType {
     protected String transcript;        
 
     /**
-     * @return the value
+     * @return the dnaEvidence
      */
-    public String getValue() {
-        return value;
+    public DnaEvidenceType getDnaEvidence() {
+        return dnaEvidence;
     }
 
     /**
-     * @param value the value to set
+     * @param dnaEvidence the dnaEvidence to set
      */
-    public void setValue(String value) {
-        this.value = value;
+    public void setDnaEvidence(DnaEvidenceType dnaEvidence) {
+        this.dnaEvidence = dnaEvidence;
     }
 
+    /**
+     * @return the rnaEvidence
+     */
+    public RnaEvidenceType getRnaEvidence() {
+        return rnaEvidence;
+    }
+
+    /**
+     * @param rnaEvidence the rnaEvidence to set
+     */
+    public void setRnaEvidence(RnaEvidenceType rnaEvidence) {
+        this.rnaEvidence = rnaEvidence;
+    }    
+
+    /**
+     * @return the alleleFraction
+     */
+    public Float getAlleleFraction() {
+        return alleleFraction;
+    }
+
+    /**
+     * @param alleleFraction the alleleFraction to set
+     */
+    public void setAlleleFraction(Float alleleFraction) {
+        this.alleleFraction = alleleFraction;
+    }
+    
     /**
      * @return the cdsEffect
      */
@@ -116,6 +154,20 @@ public class ShortVariantType {
      */
     public void setDepth(Short depth) {
         this.depth = depth;
+    }
+
+    /**
+     * @return the equivocal
+     */
+    public boolean isEquivocal() {
+        return equivocal;
+    }
+
+    /**
+     * @param equivocal the equivocal to set
+     */
+    public void setEquivocal(boolean equivocal) {
+        this.equivocal = equivocal;
     }
 
     /**

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/ShortVariantsType.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/ShortVariantsType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/TumorMutationBurdenType.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/TumorMutationBurdenType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2017 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -36,34 +36,23 @@ import javax.xml.bind.annotation.*;
 
 /**
  *
- * @author Prithi Chakrapani, ochoaa
+ * @author ochoaa
  */
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlType(name = "QualityControlType", propOrder = { 
-    "metrics" 
+@XmlType(name = "TumorMutationBurdenType", propOrder = {
+    "status"
 })
-public class QualityControlType {
+public class TumorMutationBurdenType {
     
     @XmlElement(required = true)
-    protected MetricsType metrics;
+    protected String status; 
+
+    @XmlAttribute(name = "score")
+    protected Float score;
     
-    @XmlAttribute(name = "status")
-    protected String status;
-
-    /**
-     * @return the metrics
-     */
-    public MetricsType getMetrics() {
-        return metrics;
-    }
-
-    /**
-     * @param metrics the metrics to set
-     */
-    public void setMetrics(MetricsType metrics) {
-        this.metrics = metrics;
-    }
-
+    @XmlAttribute(name = "unit")
+    protected String unit;
+    
     /**
      * @return the status
      */
@@ -76,6 +65,34 @@ public class QualityControlType {
      */
     public void setStatus(String status) {
         this.status = status;
+    }
+
+    /**
+     * @return the score
+     */
+    public Float getScore() {
+        return score;
+    }
+
+    /**
+     * @param score the score to set
+     */
+    public void setScore(Float score) {
+        this.score = score;
+    }
+
+    /**
+     * @return the unit
+     */
+    public String getUnit() {
+        return unit;
+    }
+
+    /**
+     * @param unit the unit to set
+     */
+    public void setUnit(String unit) {
+        this.unit = unit;
     }
     
 }

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/VariantReportType.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/VariantReportType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016-17 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -44,42 +44,73 @@ import javax.xml.bind.annotation.*;
     "qualityControl",
     "shortVariants",
     "copyNumberAlterations",
-    "rearrangements"
+    "rearrangements",
+    "biomarkers",
+    "nonHumanContent"
 })
 public class VariantReportType {
 
-   @XmlElement(required = true)
-   protected SamplesType samples;
-   
-   @XmlElement(name = "quality-control", required = true)
-   protected QualityControlType qualityControl;
-   
-   @XmlElement(name = "short-variants", required = true)
-   protected ShortVariantsType shortVariants;
-   
-   @XmlElement(name = "copy-number-alterations", required = true)
-    protected CopyNumberAlterationsType copyNumberAlterations;
-   
-   @XmlElement(name = "rearrangements", required = true)
-    protected RearrangementsType rearrangements;
+    @XmlElement(required = true)
+    protected SamplesType samples;
 
+    @XmlElement(name = "quality-control", required = true)
+    protected QualityControlType qualityControl;
+
+    @XmlElement(name = "short-variants", required = true)
+    protected ShortVariantsType shortVariants;
+
+    @XmlElement(name = "copy-number-alterations", required = true)
+    protected CopyNumberAlterationsType copyNumberAlterations;
+
+    @XmlElement(name = "rearrangements", required = true)
+    protected RearrangementsType rearrangements;
+    
+    // to continue supporting previous schema format, 
+    // biomarkers and non-human-content XML elements are not required 
+    @XmlElement(name = "biomarkers", required = true)
+    protected BiomarkersType biomarkers;
+    
+    @XmlElement(name = "non-human-content", required = true)
+    protected NonHumanContentType nonHumanContent;
+
+    @XmlAttribute(name = "disease")
+    protected String disease;    
+    
     @XmlAttribute(name = "disease-ontology")
     protected String diseaseOntology;
     
+    @XmlAttribute(name = "flowcell-analysis")
+    protected Integer flowcellAnalysis;
+
     @XmlAttribute(name = "gender")
     protected String gender;
+
+    @XmlAttribute(name = "pathology-diagnosis")
+    protected String pathologyDiagnosis;
+    
+    @XmlAttribute(name = "percent-tumor-nuclei")
+    protected String percentTumorNuclei;
     
     @XmlAttribute(name = "pipeline-version")
     protected String pipelineVersion;
-   
+
+    @XmlAttribute(name = "purity-assessment")
+    protected String purityAssessment;
+    
+    @XmlAttribute(name = "specimen")
+    protected String specimen;
+    
     @XmlAttribute(name = "study")
     protected String study;
-    
+
     @XmlAttribute(name = "test-request")
     protected String testRequest;
     
-    @XmlAttribute(name = "purity-assessment")
-    protected String purityAssessment;
+    @XmlAttribute(name = "test-type")
+    protected String testType;
+
+    @XmlAttribute(name = "tissue-of-origin")
+    protected String tissueOfOrigin;
 
     /**
      * @return the samples
@@ -152,6 +183,48 @@ public class VariantReportType {
     }
 
     /**
+     * @return the biomarkers
+     */
+    public BiomarkersType getBiomarkers() {
+        return biomarkers;
+    }
+
+    /**
+     * @param biomarkers the biomarkers to set
+     */
+    public void setBiomarkers(BiomarkersType biomarkers) {
+        this.biomarkers = biomarkers;
+    }
+
+    /**
+     * @return the nonHumanContent
+     */
+    public NonHumanContentType getNonHumanContent() {
+        return nonHumanContent;
+    }
+
+    /**
+     * @param nonHumanContent the nonHumanContent to set
+     */
+    public void setNonHumanContent(NonHumanContentType nonHumanContent) {
+        this.nonHumanContent = nonHumanContent;
+    }
+
+    /**
+     * @return the disease
+     */
+    public String getDisease() {
+        return disease;
+    }
+
+    /**
+     * @param disease the disease to set
+     */
+    public void setDisease(String disease) {
+        this.disease = disease;
+    }
+
+    /**
      * @return the diseaseOntology
      */
     public String getDiseaseOntology() {
@@ -163,6 +236,20 @@ public class VariantReportType {
      */
     public void setDiseaseOntology(String diseaseOntology) {
         this.diseaseOntology = diseaseOntology;
+    }
+
+    /**
+     * @return the flowcellAnalysis
+     */
+    public Integer getFlowcellAnalysis() {
+        return flowcellAnalysis;
+    }
+
+    /**
+     * @param flowcellAnalysis the flowcellAnalysis to set
+     */
+    public void setFlowcellAnalysis(Integer flowcellAnalysis) {
+        this.flowcellAnalysis = flowcellAnalysis;
     }
 
     /**
@@ -180,6 +267,34 @@ public class VariantReportType {
     }
 
     /**
+     * @return the pathologyDiagnosis
+     */
+    public String getPathologyDiagnosis() {
+        return pathologyDiagnosis;
+    }
+
+    /**
+     * @param pathologyDiagnosis the pathologyDiagnosis to set
+     */
+    public void setPathologyDiagnosis(String pathologyDiagnosis) {
+        this.pathologyDiagnosis = pathologyDiagnosis;
+    }
+
+    /**
+     * @return the percentTumorNuclei
+     */
+    public String getPercentTumorNuclei() {
+        return percentTumorNuclei;
+    }
+
+    /**
+     * @param percentTumorNuclei the percentTumorNuclei to set
+     */
+    public void setPercentTumorNuclei(String percentTumorNuclei) {
+        this.percentTumorNuclei = percentTumorNuclei;
+    }
+
+    /**
      * @return the pipelineVersion
      */
     public String getPipelineVersion() {
@@ -191,6 +306,34 @@ public class VariantReportType {
      */
     public void setPipelineVersion(String pipelineVersion) {
         this.pipelineVersion = pipelineVersion;
+    }
+
+    /**
+     * @return the purityAssessment
+     */
+    public String getPurityAssessment() {
+        return purityAssessment;
+    }
+
+    /**
+     * @param purityAssessment the purityAssessment to set
+     */
+    public void setPurityAssessment(String purityAssessment) {
+        this.purityAssessment = purityAssessment;
+    }
+
+    /**
+     * @return the specimen
+     */
+    public String getSpecimen() {
+        return specimen;
+    }
+
+    /**
+     * @param specimen the specimen to set
+     */
+    public void setSpecimen(String specimen) {
+        this.specimen = specimen;
     }
 
     /**
@@ -222,17 +365,31 @@ public class VariantReportType {
     }
 
     /**
-     * @return the purityAssessment
+     * @return the testType
      */
-    public String getPurityAssessment() {
-        return purityAssessment;
+    public String getTestType() {
+        return testType;
     }
 
     /**
-     * @param purityAssessment the purityAssessment to set
+     * @param testType the testType to set
      */
-    public void setPurityAssessment(String purityAssessment) {
-        this.purityAssessment = purityAssessment;
+    public void setTestType(String testType) {
+        this.testType = testType;
     }
-    
+
+    /**
+     * @return the tissueOfOrigin
+     */
+    public String getTissueOfOrigin() {
+        return tissueOfOrigin;
+    }
+
+    /**
+     * @param tissueOfOrigin the tissueOfOrigin to set
+     */
+    public void setTissueOfOrigin(String tissueOfOrigin) {
+        this.tissueOfOrigin = tissueOfOrigin;
+    }
+
 }

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/staging/ClinicalData.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/staging/ClinicalData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016-17 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -35,6 +35,7 @@ package org.cbio.portal.pipelines.foundation.model.staging;
 import org.cbio.portal.pipelines.foundation.model.*;
 
 import java.util.*;
+import org.cbio.portal.pipelines.foundation.util.FoundationUtils;
 
 /**
  * Class for converting CaseType to ClinicalData
@@ -53,6 +54,13 @@ public class ClinicalData /*extends DataClinicalModel*/ {
     private String diseaseOntology;
     private String purityAssessment;
     private String genePanel;
+    private String diseaseClassification;
+    private String flowcellAnalysis;
+    private String officialPath;
+    private String specimen;
+    private String platform;
+    private String tumorTissueSite;
+    private Map<String, String> additionalProperties;
 
     public ClinicalData(){}
     
@@ -62,17 +70,17 @@ public class ClinicalData /*extends DataClinicalModel*/ {
         this.studyId = caseType.getFmiCase();
         this.pipelineVersion = caseType.getVariantReport().getPipelineVersion();
         
-        this.tumorNucleiPercent = "";
+        // resolve tumor nuclei percent        
+        this.tumorNucleiPercent = FoundationUtils.resolveTumorNucleiPercent(caseType);
+        
+        // resolve values for median coverage, x100 coverage, and error percent
         this.medianCoverage = "";
         this.x100Cov = "";
         this.errorPercent = "";
         try {
             List<MetricType> metricData = caseType.getVariantReport().getQualityControl().getMetrics().getMetric();
             for (MetricType m : metricData) {
-                if (m.getName().equals("Tumor Nuclei Percent") && this.tumorNucleiPercent.isEmpty()) {
-                    this.tumorNucleiPercent = m.getValue();
-                }
-                else if (m.getName().equals("Median coverage") && this.medianCoverage.isEmpty()) {
+                if (m.getName().equals("Median coverage") && this.medianCoverage.isEmpty()) {
                     this.medianCoverage = m.getValue();
                 }
                 else if (m.getName().equals("Coverage >100X") && this.x100Cov.isEmpty()) {
@@ -85,6 +93,14 @@ public class ClinicalData /*extends DataClinicalModel*/ {
         }
         catch (NullPointerException ex) {}
 
+        // set additional properties from non-human content data
+        Map<String, String> nonHumanContentData = new HashMap<>();
+        for (NonHumanType nht : caseType.getVariantReport().getNonHumanContent().getNonHuman()) {
+            nonHumanContentData.put(nht.getOrganism(), nht.getStatus());
+        }
+        this.additionalProperties = nonHumanContentData;
+        
+        // set remaining fields
         this.diseaseOntology = caseType.getVariantReport().getDiseaseOntology()!=null?
                 caseType.getVariantReport().getDiseaseOntology():"";
         this.gender = caseType.getVariantReport().getGender()!=null?
@@ -93,6 +109,18 @@ public class ClinicalData /*extends DataClinicalModel*/ {
                 caseType.getVariantReport().getPurityAssessment():"";
         this.genePanel = caseType.getVariantReport().getStudy()!=null?
                 caseType.getVariantReport().getStudy():"";
+        this.diseaseClassification = caseType.getVariantReport().getDisease()!=null?
+                caseType.getVariantReport().getDisease():"";
+        this.flowcellAnalysis = caseType.getVariantReport().getFlowcellAnalysis()!=null?
+                String.valueOf(caseType.getVariantReport().getFlowcellAnalysis()):"";
+        this.officialPath = caseType.getVariantReport().getPathologyDiagnosis()!=null?
+                caseType.getVariantReport().getPathologyDiagnosis():"";
+        this.specimen = caseType.getVariantReport().getSpecimen()!=null?
+                caseType.getVariantReport().getSpecimen():"";
+        this.platform = caseType.getVariantReport().getTestType()!=null?
+                caseType.getVariantReport().getTestType():"";
+        this.tumorTissueSite = caseType.getVariantReport().getTissueOfOrigin()!=null?
+                caseType.getVariantReport().getTissueOfOrigin():"";
     }
     
     /** 
@@ -246,6 +274,104 @@ public class ClinicalData /*extends DataClinicalModel*/ {
     public void setErrorPercent(String errorPercent) {
         this.errorPercent = errorPercent;
     }
+    
+    /**
+     * @return the diseaseClassification
+     */
+    public String getDiseaseClassification() {
+        return diseaseClassification;
+    }
+
+    /**
+     * @param diseaseClassification the diseaseClassification to set
+     */
+    public void setDiseaseClassification(String diseaseClassification) {
+        this.diseaseClassification = diseaseClassification;
+    }
+
+    /**
+     * @return the flowcellAnalysis
+     */
+    public String getFlowcellAnalysis() {
+        return flowcellAnalysis;
+    }
+
+    /**
+     * @param flowcellAnalysis the flowcellAnalysis to set
+     */
+    public void setFlowcellAnalysis(String flowcellAnalysis) {
+        this.flowcellAnalysis = flowcellAnalysis;
+    }
+
+    /**
+     * @return the officialPath
+     */
+    public String getOfficialPath() {
+        return officialPath;
+    }
+
+    /**
+     * @param officialPath the officialPath to set
+     */
+    public void setOfficialPath(String officialPath) {
+        this.officialPath = officialPath;
+    }
+
+    /**
+     * @return the specimen
+     */
+    public String getSpecimen() {
+        return specimen;
+    }
+
+    /**
+     * @param specimen the specimen to set
+     */
+    public void setSpecimen(String specimen) {
+        this.specimen = specimen;
+    }
+
+    /**
+     * @return the platform
+     */
+    public String getPlatform() {
+        return platform;
+    }
+
+    /**
+     * @param platform the platform to set
+     */
+    public void setPlatform(String platform) {
+        this.platform = platform;
+    }
+
+    /**
+     * @return the tumorTissueSite
+     */
+    public String getTumorTissueSite() {
+        return tumorTissueSite;
+    }
+
+    /**
+     * @param tumorTissueSite the tumorTissueSite to set
+     */
+    public void setTumorTissueSite(String tumorTissueSite) {
+        this.tumorTissueSite = tumorTissueSite;
+    }
+
+    /**
+     * @return the additionalProperties
+     */
+    public Map<String, String> getAdditionalProperties() {
+        return additionalProperties;
+    }
+
+    /**
+     * @param additionalProperties the additionalProperties to set
+     */
+    public void setAdditionalProperties(Map<String, String> additionalProperties) {
+        this.additionalProperties = additionalProperties;
+    }
 
     /**
      * Returns a map linking the staging file column name to the appropriate getter method.
@@ -265,6 +391,12 @@ public class ClinicalData /*extends DataClinicalModel*/ {
         map.put("DISEASE_ONTOLOGY","getDiseaseOntology");
         map.put("PURITY_ASSESSMENT","getPurityAssessment");
         map.put("GENE_PANEL","getGenePanel");
+        map.put("DISEASE_CLASSIFICATION", "getDiseaseClassification");
+        map.put("FLOWCELL_ANALYSIS", "getFlowcellAnalysis");
+        map.put("OFFICIAL_PATH", "getOfficialPath");
+        map.put("SPECIMEN", "getSpecimen");
+        map.put("PLATFORM", "getPlatform");
+        map.put("TUMOR_TISSUE_SITE", "getTumorTissueSite");
 
         return map;
     }        

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/staging/FusionData.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/staging/FusionData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -58,8 +58,8 @@ public class FusionData {
     
     public FusionData(String sampleId, RearrangementType rearrangement) {
         this.tumorSampleBarcode = sampleId;
-        this.gene = rearrangement.getTargetedGene().split("-")[0];
-        this.entrezGeneId = "0"; 
+        this.gene = rearrangement.getTargetedGene();
+        this.entrezGeneId = "0";
         
         // resolve the fusion event
         this.fusion = FoundationUtils.resolveFusionEvent(this.gene, rearrangement.getOtherGene(), 

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/staging/MutationData.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/staging/MutationData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -44,6 +44,7 @@ import org.apache.commons.logging.*;
  * @author Prithi Chakrapani, ochoaa
  */
 public class MutationData {
+    
     private static final Log LOG = LogFactory.getLog(MutationData.class);
 
     private String gene;
@@ -94,7 +95,7 @@ public class MutationData {
     public MutationData(String sampleId, ShortVariantType shortVariant) {
         this.tumorSampleBarcode = sampleId;
         this.gene = shortVariant.getGene();
-        this.entrezGeneId ="0";
+        this.entrezGeneId = "0";
         this.chromosome = shortVariant.getPosition().split(":")[0].replace("chr","");
         this.strand = "+";
         this.aaChange = shortVariant.getProteinEffect();

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/util/GeneDataUtils.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/util/GeneDataUtils.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) 2017 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.cbio.portal.pipelines.foundation.util;
+
+import java.io.*;
+import java.util.*;
+import org.apache.commons.logging.*;
+
+import org.springframework.batch.core.configuration.annotation.JobScope;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Repository;
+
+/**
+ *
+ * @author ochoaa
+ */
+@Repository
+@JobScope
+public class GeneDataUtils {
+    
+    // general constants
+    private String DELIMITER = "\t";
+    private String METADATA_PREFIX = "#";
+    private String GENE_ID_COLUMN = "GeneID";
+    private String SYMBOL_COLUMN = "Symbol";
+    private String SYNONYMS_COLUMN = "Synonyms";
+    private String TYPE_OF_GENE_COLUMN = "type_of_gene";
+    
+    // autowired maps for getting entrez from a hugo symbol and vice versa
+    private final Map<String, String> hugoGeneSymbolMap = new HashMap<>();
+    private final Map<String, String> entrezGeneIdMap = new HashMap<>();
+    private final Map<String, String> geneAliasMap = new HashMap<>();  
+    private final Set<String> ncRNABlackList = new HashSet();
+    
+    @Value("#{jobParameters[geneDataFilename]}")
+    private String geneDataFilename;
+    
+    private boolean normalizedGeneSymbols;
+
+    private static final Log LOG = LogFactory.getLog(GeneDataUtils.class);
+    
+    @Autowired
+    private void loadHumanGeneInfo() throws Exception {
+        File geneInfoFile = new File(geneDataFilename);
+        if (geneInfoFile.exists()) {
+            LOG.info("Loading data from: " + geneDataFilename);
+            FileReader reader = new FileReader(geneInfoFile);
+            BufferedReader buf = new BufferedReader(reader);
+            String line = buf.readLine();
+            List<String> header = new ArrayList();
+            while (line != null) {
+                if (line.startsWith("#")) {
+                    header = Arrays.asList(splitDataFields(line));
+                    continue;
+                }
+                List<String> parts = Arrays.asList(line.split("\t"));
+                String entrezId = parts.get(header.indexOf(GENE_ID_COLUMN));
+                String hugoSymbol = parts.get(header.indexOf(SYMBOL_COLUMN));
+                String typeOfGene = parts.get(header.indexOf(TYPE_OF_GENE_COLUMN));
+                
+                // add ncRNAs to blacklist
+                if (typeOfGene.equals("ncRNA")) {
+                    ncRNABlackList.add(hugoSymbol);
+                }
+                
+                // add values to appropriate data map
+                hugoGeneSymbolMap.put(hugoSymbol, entrezId);
+                entrezGeneIdMap.put(entrezId, hugoSymbol);
+                String synonyms = parts.get(header.indexOf(SYNONYMS_COLUMN));
+                if (!synonyms.equals("-")) {
+                    for (String alias : synonyms.split("\\|")) {
+                        geneAliasMap.put(alias, hugoSymbol);
+                    }
+                }
+                line = buf.readLine();
+            }
+            buf.close();
+            this.normalizedGeneSymbols = true;
+        }
+        else {
+            LOG.warn("Skipping gene symbol normalization! " + 
+                    "\n\t--> To download the data and enable this feature, please refer to the fmi-convert Wiki page at: https://github.com/cBioPortal/fmi-converter/wiki/Downloading-Homo_sapiens.gene_info-data\n");
+            this.normalizedGeneSymbols = false;
+        }
+    }
+    
+    /**
+     * Light string processing/cleanup for tab delimited files.
+     * 
+     * @param line
+     * @return String[]
+     */
+    private String[] splitDataFields(String line) {
+        line = line.replaceAll("^" + METADATA_PREFIX + "+", "");
+        String[] fields = line.split(DELIMITER, -1);
+
+        return fields;                   
+    }
+    
+    /**
+     * Returns the header of a given datafile.
+     * 
+     * @param dataFile
+     * @return String[]
+     * @throws IOException 
+     */
+    private String[] getFileHeader(File dataFile) throws IOException {
+        String[] columnNames;
+        
+        try (FileReader reader = new FileReader(dataFile)) {
+            BufferedReader buff = new BufferedReader(reader);            
+            String line = buff.readLine();
+            
+            // keep reading until line does not start with meta data prefix
+            while (line.startsWith(METADATA_PREFIX)) {
+                line = buff.readLine();
+            }
+            // extract the maf file header
+            columnNames = splitDataFields(line);
+            reader.close();
+        }
+        
+        return columnNames;
+    }
+    
+    /**
+     * Determines whether given symbol is a ncRNA.
+     * @param hugoSymbol
+     * @return 
+     */
+    public boolean isNcRNA(String hugoSymbol) {
+        if (!this.normalizedGeneSymbols) return false;
+        return (ncRNABlackList.contains(hugoSymbol) || FoundationUtils.NULL_EMPTY_VALUES.contains(hugoSymbol));
+    }
+    
+    /**
+     * Resolves list of gene symbols. 
+     * @param geneList
+     * @return 
+     */
+    public List<String> resolveGeneSymbolList(String[] geneList) {
+        List<String> resolvedGeneList = new ArrayList();        
+        if (geneList.length == 1) {
+            // if only one gene in list then resolve single gene symbol
+            resolvedGeneList.add(resolveGeneSymbol(geneList[0]));
+        }
+        else {
+            // if more than one gene in list then it is assumed that the first
+            // gene in list contains the gene name prefix as in the case of 
+            // CDKN2A/B, which has a gene name prefix of 'CDKN2'
+            String genePrefix = geneList[0].substring(0, geneList[0].length()-geneList[1].length());
+            for (int i=0;i<geneList.length;i ++) {
+                String resolvedGene;
+                if (i==0) {
+                    resolvedGene = resolveGeneSymbol(geneList[i]);
+                }
+                else {
+                    resolvedGene = resolveGeneSymbol(genePrefix + geneList[i]);                    
+                }
+                resolvedGeneList.add(resolvedGene);
+            }
+        }
+        return resolvedGeneList;
+    }
+    
+    /**
+     * Resolves the given gene symbol.
+     * Returns the input gene symbol if could not be resolved.
+     * @param hugoSymbol
+     * @return 
+     */
+    public String resolveGeneSymbol(String hugoSymbol) {
+        // return if normalized gene data not loaded
+        if (!this.normalizedGeneSymbols) return hugoSymbol;
+        if (FoundationUtils.NULL_EMPTY_VALUES.contains(hugoSymbol)) {
+            return hugoSymbol;
+        }
+        else if (hugoGeneSymbolMap.containsKey(hugoSymbol)) {
+            return hugoSymbol;
+        }
+        else if (geneAliasMap.containsKey(hugoSymbol)) {
+            LOG.info("Gene " + hugoSymbol+ " given as alias - normalizing symbol to: " + geneAliasMap.get(hugoSymbol));
+            return geneAliasMap.get(hugoSymbol);                
+        }
+        else if (hugoSymbol.startsWith("LOC")) {
+            String entrezId = hugoSymbol.replace("LOC", "");
+            if (entrezGeneIdMap.containsKey(entrezId)) {
+                LOG.info("Gene symbol " + hugoSymbol + " contains entrez ID - normalizing symbol to: " + entrezGeneIdMap.get(entrezId));
+                geneAliasMap.put(hugoSymbol, entrezGeneIdMap.get(entrezId));
+                return entrezGeneIdMap.get(entrezId);
+            }
+        }
+        
+        return hugoSymbol;
+    }
+    
+    /**
+     * Returns the entrez gene id for a given hugo symbol.
+     * Returns '0' if hugo gene symbol map does not contain given hugo symbol.
+     * @param hugoSymbol
+     * @return 
+     */
+    public String resolveEntrezId(String hugoSymbol) {
+        if (!this.normalizedGeneSymbols) return "0";
+        return hugoGeneSymbolMap.getOrDefault(hugoSymbol, "0");
+    }
+    
+}

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>org.cbio.portal.pipelines</groupId>
   <artifactId>master</artifactId>
   <name>Foundation Medicine Converter</name>
-  <version>0.1.0</version>
+  <version>1.0.0</version>
   <packaging>pom</packaging>    
   <description>master maven module</description>
   <url>https://github.com/cBioPortal/fmi-converter/</url>


### PR DESCRIPTION
Foundation Updates for schema 2.0
* Updated converter pipeline to support the Foundation 2.0 schema changes.
* Updated license headers.

General updates: Converter now supports gene symbol mapping
* converter now updates entrez gene id for fusion, CNA, and mutation data processing and writing
* if gene alias is provided then hugo symbol is resolved
* now handles cases where given gene symbol starts with 'LOC'
* ncRNAs are now ignored when reading/processing mutation, fusion, and CNA data

Fusion data fixes: Fixed cases where gene symbols contained '/'-delimited and ';'-delimited lists of genes.

1. Sometimes values for `other-gene` attribute in XML data contain '/'-delimited gene symbols which can contain the `targeted-gene` gene symbol. The converter now returns the first gene in this list not matching the `targeted-gene` gene symbol.
2. Sometimes values for `other-gene` attribute in XML data contain ';'-delimited gene symbols which indicates that these genes are overlapping in the genome. The converter now arbitrarily returns the first gene in this list.

CNA data fixes: Handles cases where `gene` attribute contains value 'CDKN2A/B'.
* generalized for any gene value possibly containing "/"

Foundation may sometimes provide a single copy number alteration event for 'CDKN2A/B' instead of splitting this event into two distinct events, one for each gene. The converter now splits these events.

Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>