### PR TITLE
Added support for salvaging empty ref alleles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/foundation/target/
+**/src/main/resources/application.properties

--- a/foundation/pom.xml
+++ b/foundation/pom.xml
@@ -45,5 +45,9 @@
       <version>19.0</version>
       <type>jar</type>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
   </dependencies>    
 </project>

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/FoundationCompositeProcessor.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/FoundationCompositeProcessor.java
@@ -77,7 +77,7 @@ public class FoundationCompositeProcessor implements ItemProcessor<CaseType, Com
         }
         catch (NullPointerException ex ) {
             LOG.error("Error processing clinical, fusion, or mutation data for case: " + ct.getCase());
-            ex.printStackTrace();            
+            throw new RuntimeException(ex);
         }
           
         return compositeResultBean;

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/FoundationFileTasklet.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/FoundationFileTasklet.java
@@ -87,7 +87,7 @@ public class FoundationFileTasklet implements Tasklet {
                 }
                 // if non-human content list is not empty then add to map of normalized
                 // column names to external column name
-                if (!ct.getVariantReport().getNonHumanContent().getNonHuman().isEmpty()) {
+                if (ct.getVariantReport().getNonHumanContent() != null && !ct.getVariantReport().getNonHumanContent().getNonHuman().isEmpty()) {
                     for (NonHumanType nht : ct.getVariantReport().getNonHumanContent().getNonHuman()) {
                         nonHumanContentColumns.add(nht.getOrganism());
                     }

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/ensembl/Exon.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/ensembl/Exon.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2017 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.cbio.portal.pipelines.foundation.model.ensembl;
+
+import java.util.*;
+import com.fasterxml.jackson.annotation.*;
+import javax.annotation.Generated;
+
+/**
+ *
+ * @author ochoaa
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("org.jsonschema2pojo")
+@JsonPropertyOrder({
+"object_type",
+"version",
+"species",
+"assembly_name",
+"end",
+"seq_region_name",
+"db_type",
+"strand",
+"id",
+"start"
+})
+public class Exon {
+
+    @JsonProperty("object_type")
+    private String objectType;
+
+    @JsonProperty("version")
+    private Integer version;
+
+    @JsonProperty("species")
+    private String species;
+
+    @JsonProperty("assembly_name")
+    private String assemblyName;
+
+    @JsonProperty("end")
+    private Integer end;
+
+    @JsonProperty("seq_region_name")
+    private String seqRegionName;
+
+    @JsonProperty("db_type")
+    private String dbType;
+
+    @JsonProperty("strand")
+    private Integer strand;
+
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("start")
+    private Integer start;
+
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+    * No args constructor for use in serialization
+    * 
+    */
+    public Exon() {}
+
+    /**
+    * 
+    * @param id
+    * @param species
+    * @param start
+    * @param strand
+    * @param seqRegionName
+    * @param dbType
+    * @param objectType
+    * @param end
+    * @param assemblyName
+    * @param version
+    */
+    public Exon(String objectType, Integer version, String species, String assemblyName, Integer end, String seqRegionName, String dbType, Integer strand, String id, Integer start) {
+        this.objectType = objectType;
+        this.version = version;
+        this.species = species;
+        this.assemblyName = assemblyName;
+        this.end = end;
+        this.seqRegionName = seqRegionName;
+        this.dbType = dbType;
+        this.strand = strand;
+        this.id = id;
+        this.start = start;
+    }
+
+    @JsonProperty("object_type")
+    public String getObjectType() {
+        return objectType;
+    }
+
+    @JsonProperty("object_type")
+    public void setObjectType(String objectType) {
+        this.objectType = objectType;
+    }
+
+    @JsonProperty("version")
+    public Integer getVersion() {
+        return version;
+    }
+
+    @JsonProperty("version")
+    public void setVersion(Integer version) {
+        this.version = version;
+    }
+
+    @JsonProperty("species")
+    public String getSpecies() {
+        return species;
+    }
+
+    @JsonProperty("species")
+    public void setSpecies(String species) {
+        this.species = species;
+    }
+
+    @JsonProperty("assembly_name")
+    public String getAssemblyName() {
+        return assemblyName;
+    }
+
+    @JsonProperty("assembly_name")
+    public void setAssemblyName(String assemblyName) {
+        this.assemblyName = assemblyName;
+    }
+
+    @JsonProperty("end")
+    public Integer getEnd() {
+        return end;
+    }
+
+    @JsonProperty("end")
+    public void setEnd(Integer end) {
+        this.end = end;
+    }
+
+    @JsonProperty("seq_region_name")
+    public String getSeqRegionName() {
+        return seqRegionName;
+    }
+
+    @JsonProperty("seq_region_name")
+    public void setSeqRegionName(String seqRegionName) {
+        this.seqRegionName = seqRegionName;
+    }
+
+    @JsonProperty("db_type")
+    public String getDbType() {
+        return dbType;
+    }
+
+    @JsonProperty("db_type")
+    public void setDbType(String dbType) {
+        this.dbType = dbType;
+    }
+
+    @JsonProperty("strand")
+    public Integer getStrand() {
+        return strand;
+    }
+
+    @JsonProperty("strand")
+    public void setStrand(Integer strand) {
+        this.strand = strand;
+    }
+
+    @JsonProperty("id")
+    public String getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @JsonProperty("start")
+    public Integer getStart() {
+        return start;
+    }
+
+    @JsonProperty("start")
+    public void setStart(Integer start) {
+        this.start = start;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/ensembl/GeneXrefData.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/ensembl/GeneXrefData.java
@@ -1,0 +1,329 @@
+/*
+ * Copyright (c) 2016-17 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.cbio.portal.pipelines.foundation.model.ensembl;
+
+import java.util.*;
+import com.fasterxml.jackson.annotation.*;
+import javax.annotation.Generated;
+
+/**
+ *
+ * @author ochoaa
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("org.jsonschema2pojo")
+@JsonPropertyOrder({
+"source",
+"object_type",
+"logic_name",
+"seq_region_name",
+"db_type",
+"strand",
+"id",
+"Transcript",
+"version",
+"species",
+"assembly_name",
+"display_name",
+"description",
+"end",
+"biotype",
+"start"
+})
+public class GeneXrefData {
+
+    @JsonProperty("source")
+    private String source;
+
+    @JsonProperty("object_type")
+    private String objectType;
+
+    @JsonProperty("logic_name")
+    private String logicName;
+
+    @JsonProperty("seq_region_name")
+    private String seqRegionName;
+
+    @JsonProperty("db_type")
+    private String dbType;
+
+    @JsonProperty("strand")
+    private Integer strand;
+
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("Transcript")
+    private List<Transcript> transcript = new ArrayList<Transcript>();
+
+    @JsonProperty("version")
+    private Integer version;
+
+    @JsonProperty("species")
+    private String species;
+
+    @JsonProperty("assembly_name")
+    private String assemblyName;
+
+    @JsonProperty("display_name")
+    private String displayName;
+
+    @JsonProperty("description")
+    private String description;
+
+    @JsonProperty("end")
+    private Integer end;
+
+    @JsonProperty("biotype")
+    private String biotype;
+
+    @JsonProperty("start")
+    private Integer start;
+
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+    * No args constructor for use in serialization
+    * 
+    */
+    public GeneXrefData() {}
+
+    /**
+    * 
+    * @param transcript
+    * @param species
+    * @param logicName
+    * @param strand
+    * @param seqRegionName
+    * @param version
+    * @param id
+    * @param source
+    * @param start
+    * @param description
+    * @param biotype
+    * @param dbType
+    * @param displayName
+    * @param objectType
+    * @param end
+    * @param assemblyName
+    */
+    public GeneXrefData(String source, String objectType, String logicName, String seqRegionName, String dbType, Integer strand, String id, List<Transcript> transcript, Integer version, String species, String assemblyName, String displayName, String description, Integer end, String biotype, Integer start) {
+        this.source = source;
+        this.objectType = objectType;
+        this.logicName = logicName;
+        this.seqRegionName = seqRegionName;
+        this.dbType = dbType;
+        this.strand = strand;
+        this.id = id;
+        this.transcript = transcript;
+        this.version = version;
+        this.species = species;
+        this.assemblyName = assemblyName;
+        this.displayName = displayName;
+        this.description = description;
+        this.end = end;
+        this.biotype = biotype;
+        this.start = start;
+    }
+
+    @JsonProperty("source")
+    public String getSource() {
+        return source;
+    }
+
+    @JsonProperty("source")
+    public void setSource(String source) {
+        this.source = source;
+    }
+
+    @JsonProperty("object_type")
+    public String getObjectType() {
+        return objectType;
+    }
+
+    @JsonProperty("object_type")
+    public void setObjectType(String objectType) {
+        this.objectType = objectType;
+    }
+
+    @JsonProperty("logic_name")
+    public String getLogicName() {
+        return logicName;
+    }
+
+    @JsonProperty("logic_name")
+    public void setLogicName(String logicName) {
+        this.logicName = logicName;
+    }
+
+    @JsonProperty("seq_region_name")
+    public String getSeqRegionName() {
+        return seqRegionName;
+    }
+
+    @JsonProperty("seq_region_name")
+    public void setSeqRegionName(String seqRegionName) {
+        this.seqRegionName = seqRegionName;
+    }
+
+    @JsonProperty("db_type")
+    public String getDbType() {
+        return dbType;
+    }
+
+    @JsonProperty("db_type")
+    public void setDbType(String dbType) {
+        this.dbType = dbType;
+    }
+
+    @JsonProperty("strand")
+    public Integer getStrand() {
+        return strand;
+    }
+
+    @JsonProperty("strand")
+    public void setStrand(Integer strand) {
+        this.strand = strand;
+    }
+
+    @JsonProperty("id")
+    public String getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @JsonProperty("Transcript")
+    public List<Transcript> getTranscript() {
+        return transcript;
+    }
+
+    @JsonProperty("Transcript")
+    public void setTranscript(List<Transcript> transcript) {
+        this.transcript = transcript;
+    }
+
+    @JsonProperty("version")
+    public Integer getVersion() {
+        return version;
+    }
+
+    @JsonProperty("version")
+    public void setVersion(Integer version) {
+        this.version = version;
+    }
+
+    @JsonProperty("species")
+    public String getSpecies() {
+        return species;
+    }
+
+    @JsonProperty("species")
+    public void setSpecies(String species) {
+        this.species = species;
+    }
+
+    @JsonProperty("assembly_name")
+    public String getAssemblyName() {
+        return assemblyName;
+    }
+
+    @JsonProperty("assembly_name")
+    public void setAssemblyName(String assemblyName) {
+        this.assemblyName = assemblyName;
+    }
+
+    @JsonProperty("display_name")
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    @JsonProperty("display_name")
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    @JsonProperty("description")
+    public String getDescription() {
+        return description;
+    }
+
+    @JsonProperty("description")
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @JsonProperty("end")
+    public Integer getEnd() {
+        return end;
+    }
+
+    @JsonProperty("end")
+    public void setEnd(Integer end) {
+        this.end = end;
+    }
+
+    @JsonProperty("biotype")
+    public String getBiotype() {
+        return biotype;
+    }
+
+    @JsonProperty("biotype")
+    public void setBiotype(String biotype) {
+        this.biotype = biotype;
+    }
+
+    @JsonProperty("start")
+    public Integer getStart() {
+        return start;
+    }
+
+    @JsonProperty("start")
+    public void setStart(Integer start) {
+        this.start = start;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/ensembl/GenomicMapping.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/ensembl/GenomicMapping.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2017 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.cbio.portal.pipelines.foundation.model.ensembl;
+
+import java.util.*;
+import com.fasterxml.jackson.annotation.*;
+import javax.annotation.Generated;
+
+/**
+ *
+ * @author ochoaa
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("org.jsonschema2pojo")
+@JsonPropertyOrder({
+"assembly_name",
+"end",
+"seq_region_name",
+"gap",
+"strand",
+"coord_system",
+"rank",
+"start"
+})
+public class GenomicMapping {
+
+    @JsonProperty("assembly_name")
+    private String assemblyName;
+
+    @JsonProperty("end")
+    private Integer end;
+
+    @JsonProperty("seq_region_name")
+    private String seqRegionName;
+
+    @JsonProperty("gap")
+    private Integer gap;
+
+    @JsonProperty("strand")
+    private Integer strand;
+
+    @JsonProperty("coord_system")
+    private String coordSystem;
+
+    @JsonProperty("rank")
+    private Integer rank;
+
+    @JsonProperty("start")
+    private Integer start;
+
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+    * No args constructor for use in serialization
+    * 
+    */
+    public GenomicMapping() {}
+    
+    /**
+     * 
+     * @param assemblyName
+     * @param end
+     * @param seqRegionName
+     * @param gap
+     * @param strand
+     * @param coordSystem
+     * @param rank
+     * @param start 
+     */
+    public GenomicMapping(String assemblyName, Integer end, String seqRegionName, Integer gap, Integer strand, String coordSystem, Integer rank, Integer start) {
+        this.assemblyName = assemblyName;
+        this.end = end;
+        this.seqRegionName = seqRegionName;
+        this.gap = gap;
+        this.strand = strand;
+        this.coordSystem = coordSystem;
+        this.rank = rank;
+        this.start = start;
+    }
+    
+    @JsonProperty("assembly_name")
+    public String getAssemblyName() {
+        return assemblyName;
+    }
+
+    @JsonProperty("assembly_name")
+    public void setAssemblyName(String assemblyName) {
+        this.assemblyName = assemblyName;
+    }
+
+    @JsonProperty("end")
+    public Integer getEnd() {
+        return end;
+    }
+
+    @JsonProperty("end")
+    public void setEnd(Integer end) {
+        this.end = end;
+    }
+
+    @JsonProperty("seq_region_name")
+    public String getSeqRegionName() {
+        return seqRegionName;
+    }
+
+    @JsonProperty("seq_region_name")
+    public void setSeqRegionName(String seqRegionName) {
+        this.seqRegionName = seqRegionName;
+    }
+
+    @JsonProperty("gap")
+    public Integer getGap() {
+        return gap;
+    }
+
+    @JsonProperty("gap")
+    public void setGap(Integer gap) {
+        this.gap = gap;
+    }
+
+    @JsonProperty("strand")
+    public Integer getStrand() {
+        return strand;
+    }
+
+    @JsonProperty("strand")
+    public void setStrand(Integer strand) {
+        this.strand = strand;
+    }
+
+    @JsonProperty("coord_system")
+    public String getCoordSystem() {
+        return coordSystem;
+    }
+
+    @JsonProperty("coord_system")
+    public void setCoordSystem(String coordSystem) {
+        this.coordSystem = coordSystem;
+    }
+
+    @JsonProperty("rank")
+    public Integer getRank() {
+        return rank;
+    }
+
+    @JsonProperty("rank")
+    public void setRank(Integer rank) {
+        this.rank = rank;
+    }
+
+    @JsonProperty("start")
+    public Integer getStart() {
+        return start;
+    }
+
+    @JsonProperty("start")
+    public void setStart(Integer start) {
+        this.start = start;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/ensembl/GenomicSequence.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/ensembl/GenomicSequence.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2017 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.cbio.portal.pipelines.foundation.model.ensembl;
+
+import java.util.*;
+import com.fasterxml.jackson.annotation.*;
+import javax.annotation.Generated;
+
+/**
+ *
+ * @author ochoaa
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("org.jsonschema2pojo")
+@JsonPropertyOrder({
+"id",
+"seq",
+"molecule"
+})
+public class GenomicSequence {
+
+    @JsonProperty("id")
+    private String id;
+    
+    @JsonProperty("seq")
+    private String seq;
+    
+    @JsonProperty("molecule")
+    private String molecule;
+    
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+    * No args constructor for use in serialization
+    * 
+    */
+    public GenomicSequence() {}
+    
+    /**
+     * 
+     * @param id
+     * @param seq
+     * @param molecule 
+     */
+    public GenomicSequence(String id, String seq, String molecule) {
+        this.id = id;
+        this.seq = seq;
+        this.molecule = molecule;
+    }
+    
+    @JsonProperty("id")
+    public String getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @JsonProperty("seq")
+    public String getSeq() {
+        return seq;
+    }
+
+    @JsonProperty("seq")
+    public void setSeq(String seq) {
+        this.seq = seq;
+    }
+
+    @JsonProperty("molecule")
+    public String getMolecule() {
+        return molecule;
+    }
+
+    @JsonProperty("molecule")
+    public void setMolecule(String molecule) {
+        this.molecule = molecule;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/ensembl/ProteinGenomicMapping.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/ensembl/ProteinGenomicMapping.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2017 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.cbio.portal.pipelines.foundation.model.ensembl;
+
+import java.util.*;
+import com.fasterxml.jackson.annotation.*;
+import javax.annotation.Generated;
+
+/**
+ *
+ * @author ochoaa
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("org.jsonschema2pojo")
+@JsonPropertyOrder({
+"mappings"
+})
+public class ProteinGenomicMapping {
+    
+    @JsonProperty("mappings")
+    private List<GenomicMapping> mappings = null;
+    
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+    
+    /**
+    * No args constructor for use in serialization
+    * 
+    */
+    public ProteinGenomicMapping() {}
+    
+    /**
+     * 
+     * @param mappings 
+     */
+    public ProteinGenomicMapping(List<GenomicMapping> mappings) {
+        this.mappings = mappings;
+    }
+    
+    @JsonProperty("mappings")
+    public List<GenomicMapping> getMappings() {
+        return mappings;
+    }
+
+    @JsonProperty("mappings")
+    public void setMappings(List<GenomicMapping> mappings) {
+        this.mappings = mappings;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/ensembl/Transcript.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/ensembl/Transcript.java
@@ -1,0 +1,362 @@
+/*
+ * Copyright (c) 2017 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.cbio.portal.pipelines.foundation.model.ensembl;
+
+import java.util.*;
+import com.fasterxml.jackson.annotation.*;
+import javax.annotation.Generated;
+
+/**
+ *
+ * @author ochoaa
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("org.jsonschema2pojo")
+@JsonPropertyOrder({
+"source",
+"object_type",
+"logic_name",
+"Exon",
+"Parent",
+"seq_region_name",
+"db_type",
+"is_canonical",
+"strand",
+"id",
+"version",
+"species",
+"assembly_name",
+"display_name",
+"end",
+"biotype",
+"Translation",
+"start"
+})
+public class Transcript {
+
+    @JsonProperty("source")
+    private String source;
+    
+    @JsonProperty("object_type")
+    private String objectType;
+    
+    @JsonProperty("logic_name")
+    private String logicName;
+    
+    @JsonProperty("Exon")
+    private List<Exon> exon = new ArrayList<Exon>();
+    
+    @JsonProperty("Parent")
+    private String parent;
+    
+    @JsonProperty("seq_region_name")
+    private String seqRegionName;
+    
+    @JsonProperty("db_type")
+    private String dbType;
+    
+    @JsonProperty("is_canonical")
+    private Integer isCanonical;
+    
+    @JsonProperty("strand")
+    private Integer strand;
+    
+    @JsonProperty("id")
+    private String id;
+    
+    @JsonProperty("version")
+    private Integer version;
+    
+    @JsonProperty("species")
+    private String species;
+    
+    @JsonProperty("assembly_name")
+    private String assemblyName;
+    
+    @JsonProperty("display_name")
+    private String displayName;
+    
+    @JsonProperty("end")
+    private Integer end;
+    
+    @JsonProperty("biotype")
+    private String biotype;
+    
+    @JsonProperty("Translation")
+    private Translation translation;
+    
+    @JsonProperty("start")
+    private Integer start;
+    
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+    * No args constructor for use in serialization
+    * 
+    */
+    public Transcript() {}
+
+    /**
+    * 
+    * @param translation
+    * @param species
+    * @param logicName
+    * @param strand
+    * @param isCanonical
+    * @param parent
+    * @param seqRegionName
+    * @param exon
+    * @param version
+    * @param id
+    * @param source
+    * @param start
+    * @param biotype
+    * @param displayName
+    * @param dbType
+    * @param objectType
+    * @param end
+    * @param assemblyName
+    */
+    public Transcript(String source, String objectType, String logicName, List<Exon> exon, String parent, String seqRegionName, String dbType, Integer isCanonical, Integer strand, String id, Integer version, String species, String assemblyName, String displayName, Integer end, String biotype, Translation translation, Integer start) {
+        this.source = source;
+        this.objectType = objectType;
+        this.logicName = logicName;
+        this.exon = exon;
+        this.parent = parent;
+        this.seqRegionName = seqRegionName;
+        this.dbType = dbType;
+        this.isCanonical = isCanonical;
+        this.strand = strand;
+        this.id = id;
+        this.version = version;
+        this.species = species;
+        this.assemblyName = assemblyName;
+        this.displayName = displayName;
+        this.end = end;
+        this.biotype = biotype;
+        this.translation = translation;
+        this.start = start;
+    }
+
+    @JsonProperty("source")
+    public String getSource() {
+        return source;
+    }
+
+    @JsonProperty("source")
+    public void setSource(String source) {
+        this.source = source;
+    }
+
+    @JsonProperty("object_type")
+    public String getObjectType() {
+        return objectType;
+    }
+
+    @JsonProperty("object_type")
+    public void setObjectType(String objectType) {
+        this.objectType = objectType;
+    }
+
+    @JsonProperty("logic_name")
+    public String getLogicName() {
+        return logicName;
+    }
+
+    @JsonProperty("logic_name")
+    public void setLogicName(String logicName) {
+        this.logicName = logicName;
+    }
+
+    @JsonProperty("Exon")
+    public List<Exon> getExon() {
+        return exon;
+    }
+
+    @JsonProperty("Exon")
+    public void setExon(List<Exon> exon) {
+        this.exon = exon;
+    }
+
+    @JsonProperty("Parent")
+    public String getParent() {
+        return parent;
+    }
+
+    @JsonProperty("Parent")
+    public void setParent(String parent) {
+        this.parent = parent;
+    }
+
+    @JsonProperty("seq_region_name")
+    public String getSeqRegionName() {
+        return seqRegionName;
+    }
+
+    @JsonProperty("seq_region_name")
+    public void setSeqRegionName(String seqRegionName) {
+        this.seqRegionName = seqRegionName;
+    }
+
+    @JsonProperty("db_type")
+    public String getDbType() {
+        return dbType;
+    }
+
+    @JsonProperty("db_type")
+    public void setDbType(String dbType) {
+        this.dbType = dbType;
+    }
+
+    @JsonProperty("is_canonical")
+    public Integer getIsCanonical() {
+        return isCanonical;
+    }
+
+    @JsonProperty("is_canonical")
+    public void setIsCanonical(Integer isCanonical) {
+        this.isCanonical = isCanonical;
+    }
+
+    @JsonProperty("strand")
+    public Integer getStrand() {
+        return strand;
+    }
+
+    @JsonProperty("strand")
+    public void setStrand(Integer strand) {
+        this.strand = strand;
+    }
+
+    @JsonProperty("id")
+    public String getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @JsonProperty("version")
+    public Integer getVersion() {
+        return version;
+    }
+
+    @JsonProperty("version")
+    public void setVersion(Integer version) {
+        this.version = version;
+    }
+
+    @JsonProperty("species")
+    public String getSpecies() {
+        return species;
+    }
+
+    @JsonProperty("species")
+    public void setSpecies(String species) {
+        this.species = species;
+    }
+
+    @JsonProperty("assembly_name")
+    public String getAssemblyName() {
+        return assemblyName;
+    }
+
+    @JsonProperty("assembly_name")
+    public void setAssemblyName(String assemblyName) {
+        this.assemblyName = assemblyName;
+    }
+
+    @JsonProperty("display_name")
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    @JsonProperty("display_name")
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    @JsonProperty("end")
+    public Integer getEnd() {
+        return end;
+    }
+
+    @JsonProperty("end")
+    public void setEnd(Integer end) {
+        this.end = end;
+    }
+
+    @JsonProperty("biotype")
+    public String getBiotype() {
+        return biotype;
+    }
+
+    @JsonProperty("biotype")
+    public void setBiotype(String biotype) {
+        this.biotype = biotype;
+    }
+
+    @JsonProperty("Translation")
+    public Translation getTranslation() {
+        return translation;
+    }
+
+    @JsonProperty("Translation")
+    public void setTranslation(Translation translation) {
+        this.translation = translation;
+    }
+
+    @JsonProperty("start")
+    public Integer getStart() {
+        return start;
+    }
+
+    @JsonProperty("start")
+    public void setStart(Integer start) {
+        this.start = start;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+}

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/ensembl/Translation.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/ensembl/Translation.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2017 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.cbio.portal.pipelines.foundation.model.ensembl;
+
+import java.util.*;
+import com.fasterxml.jackson.annotation.*;
+import javax.annotation.Generated;
+
+/**
+ *
+ * @author ochoaa
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("org.jsonschema2pojo")
+@JsonPropertyOrder({
+"object_type",
+"species",
+"Parent",
+"end",
+"length",
+"db_type",
+"id",
+"start"
+})
+public class Translation {
+    
+    @JsonProperty("object_type")
+    private String objectType;
+    
+    @JsonProperty("species")
+    private String species;
+    
+    @JsonProperty("Parent")
+    private String parent;
+    
+    @JsonProperty("end")
+    private Integer end;
+    
+    @JsonProperty("length")
+    private Integer length;
+    
+    @JsonProperty("db_type")
+    private String dbType;
+    
+    @JsonProperty("id")
+    private String id;
+    
+    @JsonProperty("start")
+    private Integer start;
+    
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+    * No args constructor for use in serialization
+    * 
+    */
+    public Translation() {}
+
+    /**
+    * 
+    * @param id
+    * @param species
+    * @param start
+    * @param length
+    * @param parent
+    * @param dbType
+    * @param objectType
+    * @param end
+    */
+    public Translation(String objectType, String species, String parent, Integer end, Integer length, String dbType, String id, Integer start) {
+        this.objectType = objectType;
+        this.species = species;
+        this.parent = parent;
+        this.end = end;
+        this.length = length;
+        this.dbType = dbType;
+        this.id = id;
+        this.start = start;
+    }
+
+    @JsonProperty("object_type")
+    public String getObjectType() {
+        return objectType;
+    }
+
+    @JsonProperty("object_type")
+    public void setObjectType(String objectType) {
+        this.objectType = objectType;
+    }
+
+    @JsonProperty("species")
+    public String getSpecies() {
+        return species;
+    }
+
+    @JsonProperty("species")
+    public void setSpecies(String species) {
+        this.species = species;
+    }
+
+    @JsonProperty("Parent")
+    public String getParent() {
+    return parent;
+    }
+
+    @JsonProperty("Parent")
+    public void setParent(String parent) {
+        this.parent = parent;
+    }
+
+    @JsonProperty("end")
+    public Integer getEnd() {
+        return end;
+    }
+
+    @JsonProperty("end")
+    public void setEnd(Integer end) {
+        this.end = end;
+    }
+
+    @JsonProperty("length")
+    public Integer getLength() {
+        return length;
+    }
+
+    @JsonProperty("length")
+    public void setLength(Integer length) {
+        this.length = length;
+    }
+
+    @JsonProperty("db_type")
+    public String getDbType() {
+        return dbType;
+    }
+
+    @JsonProperty("db_type")
+    public void setDbType(String dbType) {
+        this.dbType = dbType;
+    }
+
+    @JsonProperty("id")
+    public String getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @JsonProperty("start")
+    public Integer getStart() {
+        return start;
+    }
+
+    @JsonProperty("start")
+    public void setStart(Integer start) {
+        this.start = start;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+}

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/staging/ClinicalData.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/staging/ClinicalData.java
@@ -41,7 +41,7 @@ import org.cbio.portal.pipelines.foundation.util.FoundationUtils;
  * Class for converting CaseType to ClinicalData
  * @author Prithi Chakrapani, ochoaa
  */
-public class ClinicalData /*extends DataClinicalModel*/ {
+public class ClinicalData {
      
     private String sampleId;
     private String gender;
@@ -68,7 +68,8 @@ public class ClinicalData /*extends DataClinicalModel*/ {
         this.sampleId = caseType.getCase();
         this.gender = caseType.getVariantReport().getGender();
         this.studyId = caseType.getFmiCase();
-        this.pipelineVersion = caseType.getVariantReport().getPipelineVersion();
+        this.pipelineVersion = caseType.getVariantReport().getPipelineVersion() != null ? 
+                caseType.getVariantReport().getPipelineVersion() : "";
         
         // resolve tumor nuclei percent        
         this.tumorNucleiPercent = FoundationUtils.resolveTumorNucleiPercent(caseType);
@@ -95,8 +96,10 @@ public class ClinicalData /*extends DataClinicalModel*/ {
 
         // set additional properties from non-human content data
         Map<String, String> nonHumanContentData = new HashMap<>();
-        for (NonHumanType nht : caseType.getVariantReport().getNonHumanContent().getNonHuman()) {
-            nonHumanContentData.put(nht.getOrganism(), nht.getStatus());
+        if (caseType.getVariantReport().getNonHumanContent() != null) {
+            for (NonHumanType nht : caseType.getVariantReport().getNonHumanContent().getNonHuman()) {
+                nonHumanContentData.put(nht.getOrganism(), nht.getStatus());
+            }
         }
         this.additionalProperties = nonHumanContentData;
         

--- a/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/staging/FusionData.java
+++ b/foundation/src/main/java/org/cbio/portal/pipelines/foundation/model/staging/FusionData.java
@@ -66,7 +66,7 @@ public class FusionData {
                 rearrangement.getDescription(), rearrangement.getComment());
 
         // resolve the rearrangement frame
-        this.frame = FoundationUtils.resolveRearrangementFrame(rearrangement.getInFrame());
+        this.frame = rearrangement.getInFrame() != null ? FoundationUtils.resolveRearrangementFrame(rearrangement.getInFrame()) : "unknown";
         
         /**
          * set defaults for MutationData.

--- a/foundation/src/main/resources/application.properties.EXAMPLE
+++ b/foundation/src/main/resources/application.properties.EXAMPLE
@@ -1,2 +1,11 @@
 spring.batch.job.enabled=false
-chunk.interval=30
+chunk.interval=50
+
+ensembl.server=http://grch37.rest.ensembl.org/
+#ensembl.endpoint.protein_accession=lookup/symbol/homo_sapiens/<GENESYMBOL>
+#ensembl.endpoint.protein_accession=lookup/symbol/homo_sapiens/<GENESYMBOL>?content-type=application/json
+#ensembl.endpoint.protein_accession=lookup/symbol/homo_sapiens/<GENESYMBOL>?content-type=application/json;expand=1
+ensembl.endpoint.protein_accession=lookup/symbol/homo_sapiens/<GENESYMBOL>?expand=1
+ensembl.endpoint.genomic_coords=map/translation/<ENSEMBL_PROTEIN_ACCESSION>/<PROTEIN_EFFECT_START>..<PROTEIN_EFFECT_END>?content-type=application/json
+ensembl.endpoint.cds.genomic_coords=map/cds/<ENSEMBL_TRANSCRIPT_ACCESSION>/<CDS_EFFECT_START>..<CDS_EFFECT_END>?content-type=application/json
+ensembl.endpoint.genomic_seq=sequence/region/human/<CHROMOSOME>:<GENOMIC_START_POSITION>..<GENOMIC_END_POSITION>?content-type=application/json


### PR DESCRIPTION
Converter attempts to salvage ref alleles given as empty strings in xml by using the Ensembl web service.

1. Get a list of transcripts by gene name from Enseml (http://grch37.rest.ensembl.org/lookup/symbol/homo_sapiens/AR?content-type=application/json;expand=1)

2. Get the Ensembl transcript accession by matching on the (adjusted) genomic start pos given in the xml (ENST00000374690)

3. Convert the cds coordinates from the xml into genomic coordinates using the Ensembl transcript accession (http://grch37.rest.ensembl.org/map/cds/ENST00000374690/1369..1407?content-type=application/json) * this is necessary since the genomic end position is not given in the xml

4. Use the chromosome and converted genomic coordinates to get the reference allele sequence (http://grch37.rest.ensembl.org/sequence/region/human/X:66766357..66766395?content-type=application/json)

Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>